### PR TITLE
猫年齢計算ページのテキストコントラスト比を改善

### DIFF
--- a/src/app/calculate-cat-age/CatAgeCalculator.tsx
+++ b/src/app/calculate-cat-age/CatAgeCalculator.tsx
@@ -64,7 +64,7 @@ export default function CatAgeCalculator() {
     <main className="container max-w-3xl mx-auto px-6 pb-10">
         {/* Hero Section */}
         <section className="section mt-6">
-          <p className="eyebrow text-sm tracking-wider uppercase text-pink-600 opacity-85 mt-6">
+          <p className="eyebrow text-sm tracking-wider uppercase text-pink-600 mt-6">
             {UI_TEXT.HEADER.EYECATCH}
           </p>
           <h1 className="text-3xl md:text-4xl leading-tight font-bold mt-1.5 mb-0">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,10 @@
 @import "tailwindcss";
 
 :root {
-  --primary: #FF69B4;         /* アウトライン/ホバーのライト */
-  --primary-strong: #E00070;  /* 主役数字/アクセント */
+  --primary: #FF69B4;
+  --primary-strong: #E00070;
   --text: #111;
-  --muted: #666;
+  --muted: #595959;
   --border: #E9E9EA;
 
   --r-sm: 8px;
@@ -54,7 +54,7 @@ body {
   font-size: 14px;
   letter-spacing: .08em;
   text-transform: uppercase;
-  color: rgba(224,0,112,.85);
+  color: rgba(224,0,112,1);
   margin-top: var(--s-3);
 }
 
@@ -229,7 +229,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: .04em;
-  color: #808080;
+  color: #595959;
   text-align: center;
 }
 
@@ -376,7 +376,7 @@ details[open] .chev {
 }
 
 footer {
-  color: #888;
+  color: #595959;
   font-size: 13px;
   margin-top: var(--s-4);
 }


### PR DESCRIPTION
## 概要
アクセシビリティ向上のためのカラーコントラスト改善を実施しました。

## 関連Issue
- Close #6

## 概要
- eyebrowクラスのopacityを削除（opacity-85 → 削除）でコントラスト向上
- --mutedカラー変数を #666 から #595959 に変更でコントラスト強化
- eyebrowスタイルのcolor値をopacity 0.85から1.0に変更
- フッター、著作権表示、その他テキスト要素のカラー値を統一（#808080, #888 → #595959）

## スクリーンショット/動画（任意）
（差分が分かる画像を貼る）

## 動作確認
- [x] 主要ブラウザでの表示/操作
- [x] スマホ幅での表示/操作
- [x] カラーコントラストチェッカーでのアクセシビリティ確認

## 備考
