### PR TITLE
fix: 見出しレベルの降順を修正（heading-order）

### DIFF
--- a/.tmp_pr_body.md
+++ b/.tmp_pr_body.md
@@ -1,0 +1,33 @@
+<!-- PR の目的を簡潔に。スクショ/動画/GIF があれば貼ってください。 -->
+Lighthouse のアクセシビリティ指摘（aria-allowed-attr）への対応に加え、構造化データの実装方法を App Router のベストプラクティスに統一しました。
+
+## 関連Issue
+- Close #18
+
+## 概要
+- `SegmentedButton`: `aria-pressed` を削除（`role="radio"` では不適切）
+- `SegmentedButton`: roving tabindex を導入（選択中のみ `tabindex=0`、非選択は `-1`）
+- `SegmentedButton`: 矢印キー（←/→/↑/↓）での移動、Space で選択をサポート
+- `SegmentedButton`: `ref` コールバックの戻り型を `void` に修正（型エラー解消）
+- `calculate-cat-calorie/page.tsx`: 構造化データ（JSON-LD）の注入を `metadata.other` に移行（`dangerouslySetInnerHTML` を削除）
+
+## スクリーンショット/動画（任意）
+（UIの見た目変更は最小。動作はキーボード操作で確認できます）
+
+## 動作確認
+- [ ] キーボードのみでの移動/選択が可能
+- [ ] 主要ブラウザでの表示/操作
+- [ ] スマホ幅での表示/操作
+
+## 影響範囲
+- `SegmentedButton` を利用している箇所（`calculate-cat-calorie` の入力UIなど）
+- `calculate-cat-calorie` ページの `<head>` 出力（JSON-LD の出力方法のみ変更）
+
+## チェックリスト
+- [ ] ESLint/Prettier を通過
+- [ ] テストコード を追加/更新（必要に応じて）
+- [ ] 文言・日本語確認
+
+## 備考
+- Vercel/CI 上での型エラー（`ref` コールバック）に対応済み。
+- 環境で `npm run build`/`npm test` の確認をお願いします。

--- a/.tmp_pr_update.md
+++ b/.tmp_pr_update.md
@@ -1,0 +1,6 @@
+<!-- 自動追記: テスト更新 -->
+
+## 追加の変更
+- E2Eテストを `aria-pressed` 前提から `aria-checked` 前提へ更新（アクセシビリティ仕様に一致）
+  - 対象: `tests/e2e/specs/calorie.basic.spec.ts`, `tests/e2e/specs/calorie.ui.spec.ts`
+

--- a/src/components/CalorieInput.tsx
+++ b/src/components/CalorieInput.tsx
@@ -51,9 +51,9 @@ export default function CalorieInput({
 
         {/* ライフステージ */}
         <div>
-          <h3 className="text-base font-bold text-gray-900 mb-1.5">
+          <h2 className="text-base font-bold text-gray-900 mb-1.5">
             {CALORIE_UI_TEXT.INPUT.LIFE_STAGE_LABEL}
-          </h3>
+          </h2>
           <SegmentedButton
             options={[
               { value: 'kitten', label: CALORIE_UI_TEXT.INPUT.STAGES.KITTEN },
@@ -87,9 +87,9 @@ export default function CalorieInput({
 
         {/* 目標 */}
         <div>
-          <h3 className="text-base font-bold text-gray-900 mb-1.5">
+          <h2 className="text-base font-bold text-gray-900 mb-1.5">
             {CALORIE_UI_TEXT.INPUT.GOAL_LABEL}
-          </h3>
+          </h2>
           <SegmentedButton
             options={[
               { value: 'maintain', label: CALORIE_UI_TEXT.INPUT.GOALS.MAINTAIN },


### PR DESCRIPTION
<!-- PR の目的を簡潔に。スクショ/動画/GIF があれば貼ってください。 -->
Lighthouse の「heading-order」指摘に対応し、フォーム内の見出し階層を h1 → h2 の降順に統一しました。

## 関連Issue
- Close #19

## 概要
- `src/components/CalorieInput.tsx`
  - 「ライフステージ」「目標」の見出しを h3 → h2 に変更
  - クラス名・見た目は維持（セマンティクスのみ修正）

## スクリーンショット/動画（任意）
（見た目の変化はありません。DOMの見出しレベルのみ変更）

## 動作確認
- [ ] ページに `h1` → `h2` と降順で見出しが並ぶ
- [ ] ページ機能（入力/選択/計算）は従来通り

## 影響範囲
- カロリー計算ページ内の入力セクションの見出し（セマンティクスのみ）

## チェックリスト
- [ ] ESLint/Prettier を通過
- [ ] テストコード（必要なし）
- [ ] 文言・日本語確認

## 備考
- E2Eは見出しタグを直接参照しておらず、失敗は発生しない前提です。
