### PR TITLE
chore: Geminiレビュー設定を調整してノイズを削減

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -2,8 +2,8 @@ have_fun: false
 language: ja  # 日本語でのレビューコメントを指定
 code_review:
   disable: false
-  comment_severity_threshold: HIGH
-  max_review_comments: 5
+  comment_severity_threshold: CRITICAL
+  max_review_comments: 2
   auto_approve: false  # 自動承認は無効
   pull_request_opened:
     help: true
@@ -11,8 +11,8 @@ code_review:
     code_review: true
     generate_summary: true  # PR概要の自動生成を有効
   pull_request_updated:
-    code_review: true
-    incremental_review: true  # 差分のみレビュー
+    code_review: false
+    incremental_review: false  # 差分のみレビュー
   ignore_paths:
     - "coverage/**"
     - "node_modules/**"


### PR DESCRIPTION
<!-- PR の目的を簡潔に。スクショ/動画/GIF があれば貼ってください。 -->

## 関連Issue
- Close #32

## 概要
- Gemini Code Assist の更新時自動レビューを無効化し、初回レビューのみ常時実行に変更
- 指摘レベルを CRITICAL に引き上げ、1 回あたりのコメント数を 2 件に制限

## 今回レビューしてほしい観点
- [x] 正確性（設定値の妥当性）

## スクリーンショット/動画（任意）
- なし

## 動作確認
- [ ] 主要ブラウザでの表示/操作
- [ ] スマホ幅での表示/操作

## 影響範囲
- Gemini Code Assist の PR 自動レビュー設定

## チェックリスト
- [ ] ESLint/Prettier を通過
- [ ] テストコード を追加
- [x] 文言・日本語確認

## 備考
- 必要な場合は `/gemini review` で手動レビューを実行してください

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `.gemini/config.yaml` to raise review severity to CRITICAL, limit comments to 2, and disable reviews on PR updates (including incremental reviews).
> 
> - **Config (`.gemini/config.yaml`)**:
>   - **Review thresholds**: `comment_severity_threshold` from `HIGH` → `CRITICAL`; `max_review_comments` from `5` → `2`.
>   - **PR updates**: Disable `pull_request_updated.code_review` and `pull_request_updated.incremental_review` (both `true` → `false`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 599c4c533958cee43e24b080818dfb5a4e3bc7a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->