### PR TITLE
サイトマップにcalculate-cat-feedingを追加

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,8 @@
 import { MetadataRoute } from 'next';
-import { formatISO } from 'date-fns';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://cat-tools.catnote.tokyo';
-  const lastModified = formatISO(new Date());
+  const lastModified = '2025-11-08';
   
   return [
     {


### PR DESCRIPTION
## 概要
- サイトマップに猫の給餌量計算ページを追加し、Search Console で検出できるようにする
- 既存の他ツールページと同じ頻度・優先度を設定

Closes #34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the `calculate-cat-feeding` URL to the sitemap and replaces per-entry `new Date()` with a fixed `lastModified` date across all entries.
> 
> - **Sitemap (`src/app/sitemap.ts`)**:
>   - Add `/${baseUrl}/calculate-cat-feeding` entry with `monthly` frequency and `0.8` priority.
>   - Replace per-entry `new Date()` with a shared constant `lastModified = '2025-11-08'` for all URLs.
>   - Ensure existing tool pages use consistent `changeFrequency: 'monthly'` and `priority` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f7cff510c79ae3cb9716f8524cdf6896048b7c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->