### PR TITLE
fix: calorie FAQPage JSON-LDをscript出力に変更

### DIFF
--- a/src/app/calculate-cat-calorie/page.tsx
+++ b/src/app/calculate-cat-calorie/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import CatCalorieCalculator from './CatCalorieCalculator';
+import JsonLdScript from '@/components/JsonLdScript';
 import { CALORIE_META, STRUCTURED_DATA } from '@/constants/text';
 
 const calorieFaqStructuredData = {
@@ -42,10 +43,7 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(calorieFaqStructuredData) }}
-      />
+      <JsonLdScript data={calorieFaqStructuredData} />
       <CatCalorieCalculator />
     </>
   );

--- a/src/components/JsonLdScript.tsx
+++ b/src/components/JsonLdScript.tsx
@@ -1,0 +1,14 @@
+type JsonLdData = Record<string, unknown> | Array<Record<string, unknown>>;
+
+type JsonLdScriptProps = {
+  data: JsonLdData;
+};
+
+export default function JsonLdScript({ data }: JsonLdScriptProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}


### PR DESCRIPTION
## 概要
- `/calculate-cat-calorie` のFAQ構造化データを `metadata.other` ではなく、`<script type="application/ld+json">` として明示出力するよう変更
- Playwright E2E が参照する `script[type="application/ld+json"]` から FAQPage を確実に取得できるように修正

## 変更ファイル
- `src/app/calculate-cat-calorie/page.tsx`

## 動作確認
- `BASE_URL=http://127.0.0.1:3010 npm run test:e2e -- --config=playwright.node18.config.ts tests/e2e/specs/calorie.basic.spec.ts -g "構造化データ（FAQPage）の存在確認"`
- `BASE_URL=http://127.0.0.1:3010 npm run test:e2e -- --config=playwright.node18.config.ts tests/e2e/specs/calorie.basic.spec.ts`
  - 結果: 18 passed

Closes #54
