### PR TITLE
SEO: /calculate-cat-feeding の canonical と OGP/Twitter をページ固有化

### DIFF
--- a/src/app/calculate-cat-feeding/page.tsx
+++ b/src/app/calculate-cat-feeding/page.tsx
@@ -1,10 +1,35 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 import CatFeedingCalculator from "@/components/CatFeedingCalculator";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "猫の給餌量計算｜1日の必要カロリーから与える目安量を自動計算",
   description:
     "1日の必要カロリーとフードのカロリー密度（kcal/100g）を入れるだけで、1日に与える目安量（g）と朝・夜に分けた1回量を自動計算します。",
+  alternates: {
+    canonical: "/calculate-cat-feeding",
+  },
+  openGraph: {
+    title: "猫の給餌量計算｜1日の必要カロリーから与える目安量を自動計算",
+    description:
+      "1日の必要カロリーとフードのカロリー密度（kcal/100g）を入れるだけで、1日に与える目安量（g）と朝・夜に分けた1回量を自動計算します。",
+    url: "https://cat-tools.catnote.tokyo/calculate-cat-feeding",
+    images: [
+      {
+        url: "/og.png",
+        width: 1200,
+        height: 630,
+        alt: "猫の給餌量計算｜1日の必要カロリーから与える目安量を自動計算",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "猫の給餌量計算｜1日の必要カロリーから与える目安量を自動計算",
+    description:
+      "1日の必要カロリーとフードのカロリー密度（kcal/100g）を入れるだけで、1日に与える目安量（g）と朝・夜に分けた1回量を自動計算します。",
+    images: ["/og.png"],
+  },
 };
 
 export default function Page() {


### PR DESCRIPTION
## 関連Issue
- Closes #51

## 概要
- `src/app/calculate-cat-feeding/page.tsx` の `metadata` を `Metadata` 型で定義
- `alternates.canonical` を `/calculate-cat-feeding` に設定
- `openGraph` の `title` `description` `url` `images` をページ固有値に設定
- `twitter` の `card` `title` `description` `images` をページ固有値に設定

## 今回レビューしてほしい観点（必要なものだけ残す）
- [x] 正確性（仕様どおり/バグの有無）
- [x] 型安全性（TS の型整合性）

## スクリーンショット/動画（任意）
- なし（メタデータ変更のみ）

## 動作確認
- [ ] 主要ブラウザでの表示/操作
- [ ] スマホ幅での表示/操作
- [x] `npm run lint` 実行（error 0）

## 影響範囲
- `/calculate-cat-feeding` の SEO（canonical / OGP / Twitter）

## チェックリスト
- [x] ESLint/Prettier を通過
- [ ] テストコード を追加
- [x] 文言・日本語確認

## 備考
- `npm run lint` の warning は既存の `coverage/**` 由来（今回差分外）
