### PR TITLE
fix: resolve color-contrast failure on cat-food-safety counter

### DIFF
--- a/src/app/cat-food-safety/CatFoodSafetyChecker.tsx
+++ b/src/app/cat-food-safety/CatFoodSafetyChecker.tsx
@@ -228,7 +228,7 @@ export default function CatFoodSafetyChecker({ allFoods, initialFood = '' }: Cat
         <form onSubmit={onSubmit} className="surface p-4 border-none rounded-2xl space-y-3" noValidate>
           <label htmlFor="food-name" className="text-sm font-semibold text-gray-700 flex items-center justify-between">
             {CAT_FOOD_SAFETY_TEXT.INPUT.LABEL}
-            <span className="text-xs text-gray-400">{`${query.trim().length}/${MAX_QUERY_LENGTH}`}</span>
+            <span className="text-xs text-gray-600">{`${query.trim().length}/${MAX_QUERY_LENGTH}`}</span>
           </label>
           <div className="flex flex-col gap-3 md:flex-row">
             <div


### PR DESCRIPTION
## 関連Issue
- Closes #81

## 概要
- `/src/app/cat-food-safety/CatFoodSafetyChecker.tsx` の文字数カウンタ色を `text-gray-400` から `text-gray-600` に変更
- Lighthouse Accessibility の `color-contrast` fail（0/40 カウンタ）解消を意図した最小修正

## 今回レビューしてほしい観点（必要なものだけ残す）
- [x] 正確性（仕様どおり/バグの有無）
- [ ] セキュリティ（入力/依存/XSS 等）
- [ ] 型安全性（TS の型整合性）
- [ ] エラーハンドリング（例外/境界値/失敗時の挙動）

## スクリーンショット/動画（任意）
- Playwright で対象ページをキャプチャ済み: `/tmp/issue-81-cat-food-safety-page.png`

## 動作確認
- [x] 主要ブラウザでの表示/操作
- [x] スマホ幅での表示/操作

## 影響範囲
- `cat-food-safety` ページの入力欄ラベル右側カウンタ文字色のみ

## チェックリスト
- [x] ESLint/Prettier を通過
- [ ] テストコード を追加
- [x] 文言・日本語確認

## 備考
- 実行コマンド:
  - `npm run lint`
  - `npm run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: updates a single Tailwind text color class for the character counter with no logic or data-flow impact.
> 
> **Overview**
> Improves accessibility on the `cat-food-safety` page by increasing the character counter text contrast (changes the counter from `text-gray-400` to `text-gray-600` in `CatFoodSafetyChecker.tsx`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bbedadfbd13066587858496367d6a312d8059ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->