### PR TITLE
fix: /LLMS.txt returns the repository guide

### DIFF
--- a/src/app/LLMS.txt/route.ts
+++ b/src/app/LLMS.txt/route.ts
@@ -11,7 +11,16 @@ export async function GET() {
         "content-type": "text/plain; charset=utf-8",
       },
     });
-  } catch {
-    return new Response("LLMS.txt not found", { status: 404 });
+  } catch (error: unknown) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return new Response("LLMS.txt not found", { status: 404 });
+    }
+    console.error("Failed to read LLMS.txt", error);
+    return new Response("Internal Server Error", { status: 500 });
   }
 }


### PR DESCRIPTION
## 関連Issue
- Ref #50

## 概要
- `GET /LLMS.txt` を返す Route Handler を `src/app/LLMS.txt/route.ts` に追加
- リポジトリ直下の `LLMS.txt` を読み込み、`text/plain` で返却
- ファイル未存在時は 404 を返却

## 今回レビューしてほしい観点（必要なものだけ残す）
- [x] 正確性（仕様どおり/バグの有無）

## スクリーンショット/動画（任意）
- ドキュメント配信ルート追加のため省略

## 動作確認
- [ ] 主要ブラウザでの表示/操作
- [ ] スマホ幅での表示/操作

## 影響範囲
- `src/app/LLMS.txt/route.ts`

## チェックリスト
- [x] ESLint/Prettier を通過
- [ ] テストコード を追加
- [x] 文言・日本語確認

## 備考
- 検証: `npm run lint` / `npm run test` は成功
