### PR TITLE
FAQ構造化データ生成ロジックの重複解消（STRUCTURED_DATAのDRY化）

### DIFF
--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -410,39 +410,28 @@ export const CALORIE_FAQ_ITEMS = [
     }
 ] as const;
 
+const toFaqStructuredDataItems = <T extends { question: string; answer: string }>(items: readonly T[]) =>
+  items.map(item => ({
+    '@type': 'Question',
+    'name': item.question,
+    'acceptedAnswer': {
+      '@type': 'Answer',
+      'text': item.answer.replace(/\n/g, ' '), // 改行を空白に変換
+    },
+  }));
+
 // 構造化データ（JSON-LD）用のテキスト
 export const STRUCTURED_DATA = {
   FAQ: {
     TYPE: 'FAQPage',
-    ITEMS: FAQ_ITEMS.map(item => ({
-      '@type': 'Question',
-      'name': item.question,
-      'acceptedAnswer': {
-        '@type': 'Answer',
-        'text': item.answer.replace(/\n/g, ' ') // 改行を空白に変換
-      }
-    }))
+    ITEMS: toFaqStructuredDataItems(FAQ_ITEMS),
   },
   CALORIE_FAQ: {
     TYPE: 'FAQPage',
-    ITEMS: CALORIE_FAQ_ITEMS.map(item => ({
-      '@type': 'Question',
-      'name': item.question,
-      'acceptedAnswer': {
-        '@type': 'Answer',
-        'text': item.answer.replace(/\n/g, ' ') // 改行を空白に変換
-      }
-    }))
+    ITEMS: toFaqStructuredDataItems(CALORIE_FAQ_ITEMS),
   },
   CAT_FOOD_SAFETY_FAQ: {
     TYPE: 'FAQPage',
-    ITEMS: CAT_FOOD_SAFETY_FAQ_ITEMS.map(item => ({
-      '@type': 'Question',
-      'name': item.question,
-      'acceptedAnswer': {
-        '@type': 'Answer',
-        'text': item.answer.replace(/\n/g, ' ') // 改行を空白に変換
-      }
-    }))
+    ITEMS: toFaqStructuredDataItems(CAT_FOOD_SAFETY_FAQ_ITEMS),
   },
 } as const;


### PR DESCRIPTION
## 関連Issue
- Closes #71

## 概要
- FAQ項目配列を JSON-LD `mainEntity` 形式へ変換する共通ヘルパー `toFaqStructuredDataItems` を追加
- `STRUCTURED_DATA.FAQ` / `STRUCTURED_DATA.CALORIE_FAQ` / `STRUCTURED_DATA.CAT_FOOD_SAFETY_FAQ` の重複変換ロジックを共通ヘルパー呼び出しに置換
- 既存の出力仕様（`Question`/`Answer` 構造および改行の空白置換）を維持

## 今回レビューしてほしい観点（必要なものだけ残す）
- [x] 正確性（仕様どおり/バグの有無）
- [x] 型安全性（TS の型整合性）

## スクリーンショット/動画（任意）
- UI変更なし

## 動作確認
- [x] `npm run lint`
- [x] `npm run test`

## 影響範囲
- `src/constants/text.ts` の FAQ 構造化データ生成ロジック

## チェックリスト
- [x] ESLint/Prettier を通過
- [ ] テストコード を追加
- [x] 文言・日本語確認

## 備考
- 既存テスト（53件）が全件成功し、JSON-LD 生成の回帰がないことを確認
