### PR TITLE
CI: run Lighthouse for all pages on main merge

### DIFF
--- a/.github/workflows/lighthouse-on-main-merge.yml
+++ b/.github/workflows/lighthouse-on-main-merge.yml
@@ -1,0 +1,93 @@
+name: Lighthouse On Main Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  lighthouse:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Start application
+        run: |
+          npm run start -- -p 3000 > /tmp/next-start.log 2>&1 &
+
+      - name: Wait for application
+        run: |
+          for i in {1..60}; do
+            if curl -sf http://127.0.0.1:3000 > /dev/null; then
+              echo "Application is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Application failed to start"
+          cat /tmp/next-start.log
+          exit 1
+
+      - name: Run Lighthouse for all pages
+        env:
+          BASE_URL: http://127.0.0.1:3000
+        run: |
+          set -euo pipefail
+
+          CHROME_FLAGS="--headless=new --no-sandbox --disable-dev-shm-usage"
+          PAGES=(
+            "/"
+            "/cat-food-safety"
+            "/calculate-cat-age"
+            "/calculate-cat-calorie"
+            "/calculate-cat-feeding"
+          )
+
+          run_lighthouse() {
+            local path="$1"
+            local url="${BASE_URL}${path}"
+            local report_file
+            report_file="$(mktemp)"
+
+            echo "=================================================="
+            echo "Running Lighthouse: ${url}"
+
+            if ! npx --yes lighthouse "${url}" \
+              --output=json \
+              --output-path="${report_file}" \
+              --quiet \
+              --chrome-flags="${CHROME_FLAGS}"; then
+              echo "::error::Lighthouse execution failed for ${url}"
+              rm -f "${report_file}"
+              return 1
+            fi
+
+            echo "Scores for ${url}:"
+            jq -r '
+              "- Performance: \((.categories.performance.score * 100) | round)",
+              "- Accessibility: \((.categories.accessibility.score * 100) | round)",
+              "- Best Practices: \((.categories[\"best-practices\"].score * 100) | round)",
+              "- SEO: \((.categories.seo.score * 100) | round)"
+            ' "${report_file}"
+
+            rm -f "${report_file}"
+          }
+
+          for page in "${PAGES[@]}"; do
+            run_lighthouse "${page}"
+          done


### PR DESCRIPTION
## 関連Issue
- Closes #82

## 概要
- `main` へのマージ完了時（`pull_request.closed` + `merged == true`）のみ起動する Lighthouse 用 workflow を追加
- CI 上でアプリを build/start し、以下 5 ページへ Lighthouse CLI を順次実行する処理を追加
  - `/`
  - `/cat-food-safety`
  - `/calculate-cat-age`
  - `/calculate-cat-calorie`
  - `/calculate-cat-feeding`
- 各ページのカテゴリスコア（Performance / Accessibility / Best Practices / SEO）を Actions ログへ出力
- 実行失敗時は失敗 URL が分かるよう `::error::` ログを出力

## 今回レビューしてほしい観点（必要なものだけ残す）
- [x] 正確性（仕様どおり/バグの有無）
- [ ] セキュリティ（入力/依存/XSS 等）
- [ ] 型安全性（TS の型整合性）
- [x] エラーハンドリング（例外/境界値/失敗時の挙動）

## スクリーンショット/動画（任意）
- なし（CI workflow 変更のみ）

## 動作確認
- [ ] 主要ブラウザでの表示/操作
- [ ] スマホ幅での表示/操作

## 影響範囲
- `.github/workflows/lighthouse-on-main-merge.yml`

## チェックリスト
- [x] ESLint/Prettier を通過
- [ ] テストコード を追加
- [x] 文言・日本語確認

## 備考
- `npm run lint` / `npm run test` をローカルで実行し、成功を確認済み
