### PR TITLE
fix: lighthouse workflow jq key quoting

### DIFF
--- a/.github/workflows/lighthouse-on-main-merge.yml
+++ b/.github/workflows/lighthouse-on-main-merge.yml
@@ -81,7 +81,7 @@ jobs:
             jq -r '
               "- Performance: \((.categories.performance.score * 100) | round)",
               "- Accessibility: \((.categories.accessibility.score * 100) | round)",
-              "- Best Practices: \((.categories[\"best-practices\"].score * 100) | round)",
+              "- Best Practices: \((.categories["best-practices"].score * 100) | round)",
               "- SEO: \((.categories.seo.score * 100) | round)"
             ' "${report_file}"
 


### PR DESCRIPTION
## 関連Issue
- Closes #91

## 概要
- `lighthouse-on-main-merge` workflow の `jq` フィルタで `best-practices` キー参照のクォートを修正
- `jq` 構文エラーでジョブが失敗する問題を解消

## 今回レビューしてほしい観点（必要なものだけ残す）
- [x] 正確性（仕様どおり/バグの有無）

## 動作確認
- [ ] 主要ブラウザでの表示/操作
- [ ] スマホ幅での表示/操作

## 影響範囲
- GitHub Actions (`.github/workflows/lighthouse-on-main-merge.yml`) のみ

## チェックリスト
- [x] ESLint/Prettier を通過 (`npm run lint`)
- [ ] テストコード を追加（既存テスト実行のみ: `npm run test`）
- [x] 文言・日本語確認（該当なし）

## 備考
- ローカルで `npm run lint` / `npm run test` 実行済み
- UI変更なし
