### PR TITLE
テクニカルSEO改善: cat-ageリダイレクト化とOGP画像404修正

### DIFF
--- a/src/app/calculate-cat-calorie/page.tsx
+++ b/src/app/calculate-cat-calorie/page.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
     siteName: CALORIE_META.OG.SITE_NAME,
     images: [
       {
-        url: '/og-cat-calorie.png',
+        url: '/og.png',
         width: 1200,
         height: 630,
         alt: CALORIE_META.OG.TITLE,
@@ -40,7 +40,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: CALORIE_META.OG.TITLE,
     description: CALORIE_META.OG.DESCRIPTION,
-    images: ['/og-cat-calorie.png'],
+    images: ['/og.png'],
   },
   alternates: {
     canonical: '/calculate-cat-calorie',

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,9 @@
 {
-  "rewrites": [
+  "redirects": [
     {
       "source": "/cat-age",
-      "destination": "/calculate-cat-age"
+      "destination": "/calculate-cat-age",
+      "permanent": true
     }
   ],
   "headers": [


### PR DESCRIPTION
## 関連Issue
- Closes #118

## 概要
- `/cat-age` を rewrite から恒久リダイレクトへ変更し、`/calculate-cat-age` との同一内容URLを解消
- カロリーページの OGP / Twitter 画像を存在する `/og.png` に差し替え、404 を解消

## 今回レビューしてほしい観点
- [x] 正確性（SEO上のURL正規化/OGP画像URLの妥当性）

## スクリーンショット/動画（任意）
- なし（設定・メタデータ修正のみ）

## 動作確認
- [x] `npm run lint`
- [x] `npm run test`

## 影響範囲
- SEO/OGP
- Vercel ルーティング設定

## チェックリスト
- [x] ESLint/Prettier を通過
- [ ] テストコード を追加（設定・メタデータのみのため未追加）
- [x] 文言・日本語確認

## 備考
- デプロイ後に `curl -I https://cat-tools.catnote.tokyo/cat-age` とカロリーページHTML上の OGP 画像URL確認を行う想定です。
