### PR TITLE
トップページにサイト説明と利用上の注意を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import JsonLdScript from '@/components/JsonLdScript';
-import { TOOLS } from '@/constants/text';
+import { HOME_ABOUT_TEXT, TOOLS } from '@/constants/text';
 import { createHomeBreadcrumbList } from '@/lib/breadcrumbStructuredData';
 
 const homeBreadcrumbStructuredData = createHomeBreadcrumbList();
@@ -39,6 +39,26 @@ export default function Home() {
               </span>
             </Link>
           ))}
+        </section>
+
+        <section
+          className="section mt-10"
+          aria-labelledby="about-site-title"
+        >
+          <h2 id="about-site-title" className="text-xl font-bold text-[var(--text)]">
+            {HOME_ABOUT_TEXT.TITLE}
+          </h2>
+          <div className="mt-3 space-y-4 text-sm leading-relaxed text-gray-700">
+            <p>{HOME_ABOUT_TEXT.DESCRIPTION}</p>
+            <div>
+              <h3 className="font-bold text-[var(--text)]">{HOME_ABOUT_TEXT.OPERATOR_TITLE}</h3>
+              <p className="mt-1">{HOME_ABOUT_TEXT.OPERATOR_DESCRIPTION}</p>
+            </div>
+            <div>
+              <h3 className="font-bold text-[var(--text)]">{HOME_ABOUT_TEXT.NOTICE_TITLE}</h3>
+              <p className="mt-1">{HOME_ABOUT_TEXT.NOTICE_DESCRIPTION}</p>
+            </div>
+          </div>
         </section>
       </main>
     </>

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -697,6 +697,18 @@ export const SHARE_UI_TEXT = {
 // トップページで表示するツール一覧
 export const TOOLS: readonly ToolItem[] = tools;
 
+export const HOME_ABOUT_TEXT = {
+  TITLE: 'このサイトについて',
+  DESCRIPTION:
+    'ねこツールズは、猫と暮らす中で必要になりやすい計算や確認をまとめた無料ツール集です。年齢、カロリー、給餌量、必要な水分量、食べ物の安全性など、日々の判断を整理するための補助として利用できます。',
+  OPERATOR_TITLE: '運営者の背景',
+  OPERATOR_DESCRIPTION:
+    '運営者はねこ検定上級に合格しており、実際に猫と暮らす中で感じた「ちょっと確認したい」をもとに、日々のケアに役立つツールを作っています。',
+  NOTICE_TITLE: 'ご利用にあたって',
+  NOTICE_DESCRIPTION:
+    '各ツールの結果は一般的な情報や目安であり、診断・治療・投薬判断を行うものではありません。猫の体調不良、誤食、急変などがある場合は、自己判断せず獣医師へ相談してください。',
+} as const;
+
 // 給餌量計算用のUI文言
 export const FEEDING_RANGE = {
   kcal: { min: 50, max: 1000 },

--- a/tests/e2e/specs/home.spec.ts
+++ b/tests/e2e/specs/home.spec.ts
@@ -10,7 +10,7 @@ test.describe('Home (/)', () => {
     await expect(page.locator('main h1')).toHaveText('ねこツールズ');
 
     // h2: カード見出し（順序を確認）
-    const h2 = page.locator('main h2');
+    const h2 = page.locator('section[aria-label="ツール一覧"] h2');
     await expect(h2).toHaveCount(5);
     await expect(h2.nth(0)).toHaveText('猫の食べ物安全性チェック');
     await expect(h2.nth(1)).toHaveText('猫の年齢計算');
@@ -25,15 +25,19 @@ test.describe('Home (/)', () => {
   });
 
   test('年齢計算カードはキーボード操作で遷移できる', async ({ page }) => {
-    await page.getByRole('link', { name: '猫の年齢計算ツールを開く' }).focus();
-    await page.keyboard.press('Enter');
-    await expect(page).toHaveURL(/\/calculate-cat-age$/);
+    const ageLink = page.getByRole('link', { name: '猫の年齢計算ツールを開く' });
+    await Promise.all([
+      page.waitForURL(/\/calculate-cat-age$/),
+      ageLink.press('Enter'),
+    ]);
   });
 
   test('カロリー計算カードはキーボード操作で遷移できる', async ({ page }) => {
-    await page.getByRole('link', { name: '猫のカロリー計算ツールを開く' }).focus();
-    await page.keyboard.press('Enter');
-    await expect(page).toHaveURL(/\/calculate-cat-calorie$/);
+    const calorieLink = page.getByRole('link', { name: '猫のカロリー計算ツールを開く' });
+    await Promise.all([
+      page.waitForURL(/\/calculate-cat-calorie$/),
+      calorieLink.press('Enter'),
+    ]);
   });
 
   test('給餌量計算カードはキーボード操作で遷移できる', async ({ page }) => {
@@ -47,6 +51,7 @@ test.describe('Home (/)', () => {
 
   test('見出し階層: h1→h2 の降順', async ({ page }) => {
     await expect(page.locator('main h1')).toHaveCount(1);
-    await expect(page.locator('main h2')).toHaveCount(5);
+    await expect(page.locator('section[aria-label="ツール一覧"] h2')).toHaveCount(5);
+    await expect(page.getByRole('heading', { level: 2, name: 'このサイトについて' })).toBeVisible();
   });
 });

--- a/tests/e2e/specs/navigation.spec.ts
+++ b/tests/e2e/specs/navigation.spec.ts
@@ -5,7 +5,7 @@ test.describe('ナビゲーション', () => {
     // ルートページにアクセスし、ホームのUIが表示される
     await page.goto('/');
     await expect(page.locator('main h1')).toHaveText('ねこツールズ');
-    const h2 = page.locator('main h2');
+    const h2 = page.locator('section[aria-label="ツール一覧"] h2');
     await expect(h2).toHaveCount(5);
     await expect(h2.nth(0)).toHaveText('猫の食べ物安全性チェック');
     await expect(h2.nth(1)).toHaveText('猫の年齢計算');


### PR DESCRIPTION
## 関連Issue
- Closes #120

## 概要
- トップページのツール一覧後に `このサイトについて` セクションを追加
- サイトの目的、運営者背景、利用上の注意を控えめな表示で追記
- ホームE2Eを新しいセクション追加後の見出し構造に合わせて更新

## 今回レビューしてほしい観点
- [x] 正確性（Issueの受け入れ条件を満たしているか）
- [x] 文言（過剰な権威主張になっていないか）

## スクリーンショット/動画（任意）
- なし

## 動作確認
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run test:e2e -- tests/e2e/specs/home.spec.ts`

## 影響範囲
- トップページ
- SEO/信頼性補足コンテンツ
- ホームE2E

## チェックリスト
- [x] ESLint/Prettier を通過
- [x] テストコード を追加/更新
- [x] 文言・日本語確認

## 備考
- `このサイトについて` はツール一覧の後に配置し、ツール利用導線を邪魔しない構成にしています。
