### PR TITLE
カロリーページに計算方法の参考情報と構造化データを追加

### DIFF
--- a/src/app/calculate-cat-calorie/CatCalorieCalculator.tsx
+++ b/src/app/calculate-cat-calorie/CatCalorieCalculator.tsx
@@ -4,7 +4,11 @@ import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { LifeStage, Goal, CatCalorieResult } from '@/types';
 import { calculateCatCalorie } from '@/lib/catCalorie';
-import { CALCULATE_CAT_AGE_PATH, CALCULATE_CAT_FEEDING_PATH } from '@/constants/paths';
+import {
+  CALCULATE_CAT_AGE_PATH,
+  CALCULATE_CAT_FEEDING_PATH,
+  CALCULATE_CAT_WATER_INTAKE_PATH,
+} from '@/constants/paths';
 import { CALORIE_UI_TEXT } from '@/constants/text';
 import { LIFE_STAGES, GOALS } from '@/constants/options';
 import CalorieInput from '@/components/CalorieInput';
@@ -93,6 +97,13 @@ function CalorieSupplementaryContent() {
             </div>
           ))}
         </div>
+        <p className="mt-5 text-sm text-gray-700 leading-relaxed text-pretty">
+          {supplementaryText.FEEDING_STEPS.WATER_INTAKE_LINK.TEXT_BEFORE}
+          <Link href={CALCULATE_CAT_WATER_INTAKE_PATH} className="text-pink-600 font-bold">
+            {supplementaryText.FEEDING_STEPS.WATER_INTAKE_LINK.LABEL}
+          </Link>
+          {supplementaryText.FEEDING_STEPS.WATER_INTAKE_LINK.TEXT_AFTER}
+        </p>
       </section>
 
       <section className="section mt-10" aria-labelledby="calorie-pitfalls">
@@ -126,6 +137,37 @@ function CalorieSupplementaryContent() {
             </p>
           ))}
         </div>
+      </section>
+
+      <section className="section mt-10" aria-labelledby="calorie-references">
+        <h2
+          id="calorie-references"
+          className="my-4 pt-4 font-extrabold text-xl md:text-2xl tracking-tight text-balance"
+        >
+          {supplementaryText.REFERENCES.TITLE}
+        </h2>
+        <div className="space-y-3">
+          {supplementaryText.REFERENCES.BODY.map((paragraph, index) => (
+            <p key={`calorie-reference-body-${index}`} className="text-sm text-gray-700 leading-relaxed text-pretty">
+              {paragraph}
+            </p>
+          ))}
+        </div>
+        <ul className="list-disc space-y-2 pl-5 text-sm text-gray-700 leading-relaxed mt-4">
+          {supplementaryText.REFERENCES.LINKS.map((source) => (
+            <li key={source.URL}>
+              <a
+                href={source.URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-pink-700 hover:text-pink-800 underline underline-offset-2 break-all"
+              >
+                {source.LABEL}
+              </a>
+              <span className="text-gray-600"> — {source.NOTE}</span>
+            </li>
+          ))}
+        </ul>
       </section>
     </>
   );

--- a/src/app/calculate-cat-calorie/page.tsx
+++ b/src/app/calculate-cat-calorie/page.tsx
@@ -22,7 +22,7 @@ const calorieWebApplicationStructuredData = {
   name: CALORIE_UI_TEXT.HEADER.TITLE,
   url: CALORIE_META.OG.URL,
   description: CALORIE_META.DESCRIPTION,
-  applicationCategory: "CalculatorApplication",
+  applicationCategory: "UtilitiesApplication",
   operatingSystem: "Any",
   inLanguage: "ja",
   isAccessibleForFree: true,

--- a/src/app/calculate-cat-calorie/page.tsx
+++ b/src/app/calculate-cat-calorie/page.tsx
@@ -16,6 +16,23 @@ const calorieBreadcrumbStructuredData = createPageBreadcrumbList({
   path: CALCULATE_CAT_CALORIE_PATH,
 });
 
+const calorieWebApplicationStructuredData = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: CALORIE_UI_TEXT.HEADER.TITLE,
+  url: CALORIE_META.OG.URL,
+  description: CALORIE_META.DESCRIPTION,
+  applicationCategory: "CalculatorApplication",
+  operatingSystem: "Any",
+  inLanguage: "ja",
+  isAccessibleForFree: true,
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "JPY",
+  },
+};
+
 export const metadata: Metadata = {
   title: CALORIE_META.TITLE,
   description: CALORIE_META.DESCRIPTION,
@@ -50,7 +67,13 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <>
-      <JsonLdScript data={[calorieFaqStructuredData, calorieBreadcrumbStructuredData]} />
+      <JsonLdScript
+        data={[
+          calorieWebApplicationStructuredData,
+          calorieFaqStructuredData,
+          calorieBreadcrumbStructuredData,
+        ]}
+      />
       <CatCalorieCalculator />
     </>
   );

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -631,6 +631,11 @@ export const CALORIE_UI_TEXT = {
         LABEL: '猫の給餌量計算ページ',
         TEXT_AFTER: 'で朝・夜の配分目安まで確認できます。',
       },
+      WATER_INTAKE_LINK: {
+        TEXT_BEFORE: '1日のフード量が決まったら、ドライ・ウェットの量をもとに',
+        LABEL: '猫の必要給水量計算ページ',
+        TEXT_AFTER: 'で水分摂取の目安も確認できます。',
+      },
     },
     PITFALLS: {
       TITLE: 'よくある失敗と見直しポイント',
@@ -657,6 +662,30 @@ export const CALORIE_UI_TEXT = {
       BODY: [
         '食事量を調整しても体重変化が大きい、食欲低下や嘔吐・下痢が続く、元気が落ちている場合は、自己調整を続けるより受診を優先してください。',
         'このページは健康管理の目安を整理するための情報であり、診断を行うものではありません。不安な変化が続く場合は、早めに動物病院へ相談してください。',
+      ],
+    },
+    REFERENCES: {
+      TITLE: '計算方法の参考情報',
+      BODY: [
+        'このツールでは、体重からRER（安静時エネルギー要求量）を求め、ライフステージや目標に応じた係数をかけて1日の必要カロリーの目安を算出しています。',
+        '係数はあくまで出発点です。シニア期、減量、増量では個体差が大きいため、体重推移や体調を見ながら調整し、判断に迷う場合は獣医師へ相談してください。',
+      ],
+      LINKS: [
+        {
+          LABEL: 'Merck Veterinary Manual: Nutritional Requirements of Small Animals',
+          URL: 'https://www.merckvetmanual.com/management-and-nutrition/nutrition-small-animals/nutritional-requirements-of-small-animals',
+          NOTE: 'RER式と猫の維持エネルギー係数を確認する参考情報',
+        },
+        {
+          LABEL: 'Pet Nutrition Alliance: MER and RER Guide',
+          URL: 'https://petnutritionalliance.org/wp-content/uploads/2023/03/MER.RER_.PNA_.pdf',
+          NOTE: 'RER/MERの考え方と減量時の係数を確認する参考情報',
+        },
+        {
+          LABEL: '2021 AAHA Nutrition and Weight Management Guidelines for Dogs and Cats',
+          URL: 'https://www.aaha.org/wp-content/uploads/globalassets/02-guidelines/2021-nutrition-and-weight-management/resourcepdfs/new-2021-aaha-nutrition-and-weight-management-guidelines-with-ref.pdf',
+          NOTE: '栄養評価、BCS、個体差を踏まえた調整の参考情報',
+        },
       ],
     },
     DISCLAIMER:

--- a/tests/e2e/specs/calorie.basic.spec.ts
+++ b/tests/e2e/specs/calorie.basic.spec.ts
@@ -83,7 +83,7 @@ test.describe('猫のカロリー計算 - 基本機能テスト', () => {
     await expect(firstFaq).not.toHaveAttribute('open');
   });
 
-  test('構造化データ（FAQPage）の存在確認', async ({ page }) => {
+  test('構造化データ（FAQPage/WebApplication）の存在確認', async ({ page }) => {
     // すべての JSON-LD を取得して解析（オブジェクト/配列の両方に対応）
     const contents = await page.locator('script[type="application/ld+json"]').allTextContents();
 
@@ -91,15 +91,28 @@ test.describe('猫のカロリー計算 - 基本機能テスト', () => {
     type FaqAnswer = { ['@type']: string; text: string };
     type FaqItem = { ['@type']: string; name: string; acceptedAnswer: FaqAnswer };
     type FaqPage = { ['@type']: string; mainEntity: FaqItem[] };
+    type WebApplication = {
+      ['@type']: string;
+      name: string;
+      applicationCategory: string;
+      operatingSystem: string;
+      inLanguage: string;
+      isAccessibleForFree: boolean;
+    };
     const isFaqPage = (v: unknown): v is FaqPage => {
       if (!v || typeof v !== 'object') return false;
       const t = (v as Record<string, unknown>)['@type'];
       const me = (v as Record<string, unknown>)['mainEntity'];
       return t === 'FAQPage' && Array.isArray(me);
     };
+    const isWebApplication = (v: unknown): v is WebApplication => {
+      if (!v || typeof v !== 'object') return false;
+      return (v as Record<string, unknown>)['@type'] === 'WebApplication';
+    };
 
     // FAQPageを含む要素を抽出
     const faqPayloads: FaqPage[] = [];
+    const webApplicationPayloads: WebApplication[] = [];
     for (const text of contents) {
       try {
         const parsed = JSON.parse(text) as unknown;
@@ -108,6 +121,9 @@ test.describe('猫のカロリー計算 - 基本機能テスト', () => {
           if (isFaqPage(item)) {
             faqPayloads.push(item);
           }
+          if (isWebApplication(item)) {
+            webApplicationPayloads.push(item);
+          }
         }
       } catch {
         // JSONでない場合はスキップ
@@ -115,6 +131,7 @@ test.describe('猫のカロリー計算 - 基本機能テスト', () => {
     }
 
     expect(faqPayloads.length).toBeGreaterThanOrEqual(1);
+    expect(webApplicationPayloads.length).toBeGreaterThanOrEqual(1);
 
     // 1つ目のFAQPageの内容を確認
     const data = faqPayloads[0];
@@ -130,6 +147,13 @@ test.describe('猫のカロリー計算 - 基本機能テスト', () => {
       expect(entry.acceptedAnswer['@type']).toBe('Answer');
       expect(entry.acceptedAnswer.text).toBeTruthy();
     }
+
+    const webApplication = webApplicationPayloads[0];
+    expect(webApplication.name).toBe('猫のカロリー計算');
+    expect(webApplication.applicationCategory).toBe('CalculatorApplication');
+    expect(webApplication.operatingSystem).toBe('Any');
+    expect(webApplication.inLanguage).toBe('ja');
+    expect(webApplication.isAccessibleForFree).toBe(true);
   });
 
   test('補助本文セクションの存在確認', async ({ page }) => {
@@ -138,8 +162,13 @@ test.describe('猫のカロリー計算 - 基本機能テスト', () => {
     await expect(page.getByRole('heading', { level: 2, name: '計算結果を給餌量に落とし込む手順' })).toBeVisible();
     await expect(page.getByRole('heading', { level: 2, name: 'よくある失敗と見直しポイント' })).toBeVisible();
     await expect(page.getByRole('heading', { level: 2, name: '受診を検討したいサイン' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 2, name: '計算方法の参考情報' })).toBeVisible();
     await expect(page.getByRole('link', { name: '猫の給餌量計算ページ' })).toHaveAttribute('href', '/calculate-cat-feeding');
     await expect(page.getByRole('link', { name: '猫の年齢計算ページ' })).toHaveAttribute('href', '/calculate-cat-age');
+    await expect(page.getByRole('link', { name: '猫の必要給水量計算ページ' })).toHaveAttribute('href', '/calculate-cat-water-intake');
+    await expect(page.getByRole('link', { name: /Merck Veterinary Manual/ })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Pet Nutrition Alliance/ })).toBeVisible();
+    await expect(page.getByRole('link', { name: /AAHA Nutrition and Weight Management Guidelines/ })).toBeVisible();
     await expect(
       page.getByText('本コンテンツは一般的な情報提供であり、診断・治療を行うものではありません。')
     ).toBeVisible();

--- a/tests/e2e/specs/calorie.basic.spec.ts
+++ b/tests/e2e/specs/calorie.basic.spec.ts
@@ -150,7 +150,7 @@ test.describe('猫のカロリー計算 - 基本機能テスト', () => {
 
     const webApplication = webApplicationPayloads[0];
     expect(webApplication.name).toBe('猫のカロリー計算');
-    expect(webApplication.applicationCategory).toBe('CalculatorApplication');
+    expect(webApplication.applicationCategory).toBe('UtilitiesApplication');
     expect(webApplication.operatingSystem).toBe('Any');
     expect(webApplication.inLanguage).toBe('ja');
     expect(webApplication.isAccessibleForFree).toBe(true);


### PR DESCRIPTION
## 関連Issue
- Closes #122

## 概要
- カロリーページに `計算方法の参考情報` セクションを追加
- 給餌量換算の流れの後に、必要給水量計算ページへの本文内リンクを追加
- カロリーページの JSON-LD に `WebApplication` を追加
- カロリーページのE2Eで参考情報リンクと構造化データを確認

## 今回レビューしてほしい観点
- [x] 正確性（参考情報・導線・構造化データがIssue要件どおりか）
- [x] 文言（増量/シニアを強い根拠として断定していないか）
- [x] 型安全性（JSON-LDとE2Eの型整合性）

## スクリーンショット/動画（任意）
- なし

## 動作確認
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run test:e2e -- tests/e2e/specs/calorie.basic.spec.ts tests/e2e/specs/calorie.compute.spec.ts tests/e2e/specs/calorie.share.spec.ts tests/e2e/specs/calorie.ui.spec.ts`

## 影響範囲
- カロリーページ本文
- SEO/構造化データ
- カロリーページE2E

## チェックリスト
- [x] ESLint/Prettier を通過
- [x] テストコード を追加/更新
- [x] 文言・日本語確認

## 備考
- 計算ロジック自体は変更していません。
- 更新日は表示していません。
