### PR TITLE
全ツールページのWebApplication構造化データを統一

### DIFF
--- a/src/app/calculate-cat-age/page.tsx
+++ b/src/app/calculate-cat-age/page.tsx
@@ -4,6 +4,7 @@ import JsonLdScript from '@/components/JsonLdScript';
 import { CALCULATE_CAT_AGE_PATH } from '@/constants/paths';
 import { META, FAQ_ITEMS, UI_TEXT } from '@/constants/text';
 import { createPageBreadcrumbList } from '@/lib/breadcrumbStructuredData';
+import { createWebApplicationStructuredData } from '@/lib/webApplicationStructuredData';
 
 const ageBreadcrumbStructuredData = createPageBreadcrumbList({
   name: UI_TEXT.BREADCRUMBS.CAT_AGE_CALCULATOR,
@@ -11,21 +12,12 @@ const ageBreadcrumbStructuredData = createPageBreadcrumbList({
 });
 
 const ageStructuredData = [
-  {
-    "@context": "https://schema.org",
-    "@type": "WebApplication",
-    "name": "猫の年齢計算ツール",
-    "url": META.OG.URL,
-    "description": META.DESCRIPTION,
-    "applicationCategory": "CalculatorApplication",
-    "operatingSystem": "Any",
-    "browserRequirements": "Requires JavaScript",
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "JPY"
-    }
-  },
+  createWebApplicationStructuredData({
+    name: '猫の年齢計算',
+    url: META.OG.URL,
+    description: '誕生日から猫の年齢を人間年齢の目安に換算し、ライフステージも確認できます。',
+    applicationCategory: 'CalculatorApplication',
+  }),
   {
     "@context": "https://schema.org",
     "@type": "FAQPage",

--- a/src/app/calculate-cat-age/page.tsx
+++ b/src/app/calculate-cat-age/page.tsx
@@ -16,7 +16,7 @@ const ageStructuredData = [
     name: '猫の年齢計算',
     url: META.OG.URL,
     description: '誕生日から猫の年齢を人間年齢の目安に換算し、ライフステージも確認できます。',
-    applicationCategory: 'CalculatorApplication',
+    applicationCategory: 'UtilitiesApplication',
   }),
   {
     "@context": "https://schema.org",

--- a/src/app/calculate-cat-calorie/page.tsx
+++ b/src/app/calculate-cat-calorie/page.tsx
@@ -4,6 +4,7 @@ import JsonLdScript from '@/components/JsonLdScript';
 import { CALCULATE_CAT_CALORIE_PATH } from '@/constants/paths';
 import { CALORIE_META, CALORIE_UI_TEXT, STRUCTURED_DATA } from '@/constants/text';
 import { createPageBreadcrumbList } from '@/lib/breadcrumbStructuredData';
+import { createWebApplicationStructuredData } from '@/lib/webApplicationStructuredData';
 
 const calorieFaqStructuredData = {
   "@context": "https://schema.org",
@@ -16,22 +17,12 @@ const calorieBreadcrumbStructuredData = createPageBreadcrumbList({
   path: CALCULATE_CAT_CALORIE_PATH,
 });
 
-const calorieWebApplicationStructuredData = {
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
+const calorieWebApplicationStructuredData = createWebApplicationStructuredData({
   name: CALORIE_UI_TEXT.HEADER.TITLE,
   url: CALORIE_META.OG.URL,
-  description: CALORIE_META.DESCRIPTION,
-  applicationCategory: "UtilitiesApplication",
-  operatingSystem: "Any",
-  inLanguage: "ja",
-  isAccessibleForFree: true,
-  offers: {
-    "@type": "Offer",
-    price: "0",
-    priceCurrency: "JPY",
-  },
-};
+  description: '体重と条件から猫の1日の必要カロリーの目安を計算します。',
+  applicationCategory: 'CalculatorApplication',
+});
 
 export const metadata: Metadata = {
   title: CALORIE_META.TITLE,

--- a/src/app/calculate-cat-calorie/page.tsx
+++ b/src/app/calculate-cat-calorie/page.tsx
@@ -21,7 +21,7 @@ const calorieWebApplicationStructuredData = createWebApplicationStructuredData({
   name: CALORIE_UI_TEXT.HEADER.TITLE,
   url: CALORIE_META.OG.URL,
   description: '体重と条件から猫の1日の必要カロリーの目安を計算します。',
-  applicationCategory: 'CalculatorApplication',
+  applicationCategory: 'UtilitiesApplication',
 });
 
 export const metadata: Metadata = {

--- a/src/app/calculate-cat-feeding/page.tsx
+++ b/src/app/calculate-cat-feeding/page.tsx
@@ -4,10 +4,18 @@ import JsonLdScript from "@/components/JsonLdScript";
 import { CALCULATE_CAT_FEEDING_PATH } from "@/constants/paths";
 import { FEEDING_UI_TEXT } from "@/constants/text";
 import { createPageBreadcrumbList } from "@/lib/breadcrumbStructuredData";
+import { createWebApplicationStructuredData } from "@/lib/webApplicationStructuredData";
 
 const feedingBreadcrumbStructuredData = createPageBreadcrumbList({
   name: FEEDING_UI_TEXT.BREADCRUMBS.FEEDING_CALCULATOR,
   path: CALCULATE_CAT_FEEDING_PATH,
+});
+
+const feedingWebApplicationStructuredData = createWebApplicationStructuredData({
+  name: '猫の給餌量計算',
+  url: 'https://cat-tools.catnote.tokyo/calculate-cat-feeding',
+  description: '1日の必要カロリーとフードのカロリー密度から、1日量と朝夜の目安量を計算します。',
+  applicationCategory: 'CalculatorApplication',
 });
 
 export const metadata: Metadata = {
@@ -43,7 +51,7 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <>
-      <JsonLdScript data={feedingBreadcrumbStructuredData} />
+      <JsonLdScript data={[feedingWebApplicationStructuredData, feedingBreadcrumbStructuredData]} />
       <CatFeedingCalculator />
     </>
   );

--- a/src/app/calculate-cat-feeding/page.tsx
+++ b/src/app/calculate-cat-feeding/page.tsx
@@ -15,7 +15,7 @@ const feedingWebApplicationStructuredData = createWebApplicationStructuredData({
   name: '猫の給餌量計算',
   url: 'https://cat-tools.catnote.tokyo/calculate-cat-feeding',
   description: '1日の必要カロリーとフードのカロリー密度から、1日量と朝夜の目安量を計算します。',
-  applicationCategory: 'CalculatorApplication',
+  applicationCategory: 'UtilitiesApplication',
 });
 
 export const metadata: Metadata = {

--- a/src/app/calculate-cat-water-intake/page.tsx
+++ b/src/app/calculate-cat-water-intake/page.tsx
@@ -25,7 +25,7 @@ const waterIntakeWebApplicationStructuredData = createWebApplicationStructuredDa
   name: '猫の必要給水量計算',
   url: WATER_INTAKE_META.OG.URL,
   description: '体重とフード量から、総水分目標・食事由来水分・器からの飲水目標を計算します。',
-  applicationCategory: 'CalculatorApplication',
+  applicationCategory: 'UtilitiesApplication',
 });
 
 export const metadata: Metadata = {

--- a/src/app/calculate-cat-water-intake/page.tsx
+++ b/src/app/calculate-cat-water-intake/page.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/constants/text';
 import { CALCULATE_CAT_WATER_INTAKE_PATH } from '@/constants/paths';
 import { createPageBreadcrumbList } from '@/lib/breadcrumbStructuredData';
+import { createWebApplicationStructuredData } from '@/lib/webApplicationStructuredData';
 import CatWaterIntakeCalculator from './CatWaterIntakeCalculator';
 
 const waterIntakeFaqStructuredData = {
@@ -18,6 +19,13 @@ const waterIntakeFaqStructuredData = {
 const waterIntakeBreadcrumbStructuredData = createPageBreadcrumbList({
   name: WATER_INTAKE_UI_TEXT.BREADCRUMBS.WATER_INTAKE_CALCULATOR,
   path: CALCULATE_CAT_WATER_INTAKE_PATH,
+});
+
+const waterIntakeWebApplicationStructuredData = createWebApplicationStructuredData({
+  name: '猫の必要給水量計算',
+  url: WATER_INTAKE_META.OG.URL,
+  description: '体重とフード量から、総水分目標・食事由来水分・器からの飲水目標を計算します。',
+  applicationCategory: 'CalculatorApplication',
 });
 
 export const metadata: Metadata = {
@@ -54,7 +62,13 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <>
-      <JsonLdScript data={[waterIntakeFaqStructuredData, waterIntakeBreadcrumbStructuredData]} />
+      <JsonLdScript
+        data={[
+          waterIntakeWebApplicationStructuredData,
+          waterIntakeFaqStructuredData,
+          waterIntakeBreadcrumbStructuredData,
+        ]}
+      />
       <CatWaterIntakeCalculator />
     </>
   );

--- a/src/app/cat-food-safety/page.tsx
+++ b/src/app/cat-food-safety/page.tsx
@@ -5,6 +5,7 @@ import { CAT_FOOD_SAFETY_PATH } from '@/constants/paths';
 import { CAT_FOOD_SAFETY_META, CAT_FOOD_SAFETY_TEXT, STRUCTURED_DATA } from '@/constants/text';
 import { createPageBreadcrumbList } from '@/lib/breadcrumbStructuredData';
 import { getAllCatFoods } from '@/lib/catFoodSafety';
+import { createWebApplicationStructuredData } from '@/lib/webApplicationStructuredData';
 
 export const metadata: Metadata = {
   title: CAT_FOOD_SAFETY_META.TITLE,
@@ -48,12 +49,24 @@ const catFoodSafetyFaqStructuredData = {
   mainEntity: STRUCTURED_DATA.CAT_FOOD_SAFETY_FAQ.ITEMS,
 };
 
+const catFoodSafetyWebApplicationStructuredData = createWebApplicationStructuredData({
+  name: '猫の食べ物安全性チェック',
+  url: CAT_FOOD_SAFETY_META.OG.URL,
+  description: '食材名から猫にとって安全・注意・危険の目安を確認できます。',
+  applicationCategory: 'ReferenceApplication',
+});
+
 export default function Page() {
   const allFoods = getAllCatFoods();
   return (
     <>
-      <JsonLdScript data={catFoodSafetyBreadcrumbStructuredData} />
-      <JsonLdScript data={catFoodSafetyFaqStructuredData} />
+      <JsonLdScript
+        data={[
+          catFoodSafetyWebApplicationStructuredData,
+          catFoodSafetyBreadcrumbStructuredData,
+          catFoodSafetyFaqStructuredData,
+        ]}
+      />
       <CatFoodSafetyChecker allFoods={allFoods} />
     </>
   );

--- a/src/lib/webApplicationStructuredData.ts
+++ b/src/lib/webApplicationStructuredData.ts
@@ -2,7 +2,7 @@ type WebApplicationStructuredDataInput = {
   name: string;
   url: string;
   description: string;
-  applicationCategory: 'CalculatorApplication' | 'ReferenceApplication';
+  applicationCategory: 'UtilitiesApplication' | 'ReferenceApplication';
 };
 
 export function createWebApplicationStructuredData({

--- a/src/lib/webApplicationStructuredData.ts
+++ b/src/lib/webApplicationStructuredData.ts
@@ -1,0 +1,30 @@
+type WebApplicationStructuredDataInput = {
+  name: string;
+  url: string;
+  description: string;
+  applicationCategory: 'CalculatorApplication' | 'ReferenceApplication';
+};
+
+export function createWebApplicationStructuredData({
+  name,
+  url,
+  description,
+  applicationCategory,
+}: WebApplicationStructuredDataInput) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name,
+    url,
+    description,
+    applicationCategory,
+    operatingSystem: 'Any',
+    inLanguage: 'ja',
+    isAccessibleForFree: true,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'JPY',
+    },
+  };
+}

--- a/tests/e2e/specs/calorie.basic.spec.ts
+++ b/tests/e2e/specs/calorie.basic.spec.ts
@@ -150,7 +150,7 @@ test.describe('猫のカロリー計算 - 基本機能テスト', () => {
 
     const webApplication = webApplicationPayloads[0];
     expect(webApplication.name).toBe('猫のカロリー計算');
-    expect(webApplication.applicationCategory).toBe('UtilitiesApplication');
+    expect(webApplication.applicationCategory).toBe('CalculatorApplication');
     expect(webApplication.operatingSystem).toBe('Any');
     expect(webApplication.inLanguage).toBe('ja');
     expect(webApplication.isAccessibleForFree).toBe(true);

--- a/tests/e2e/specs/calorie.basic.spec.ts
+++ b/tests/e2e/specs/calorie.basic.spec.ts
@@ -150,7 +150,7 @@ test.describe('猫のカロリー計算 - 基本機能テスト', () => {
 
     const webApplication = webApplicationPayloads[0];
     expect(webApplication.name).toBe('猫のカロリー計算');
-    expect(webApplication.applicationCategory).toBe('CalculatorApplication');
+    expect(webApplication.applicationCategory).toBe('UtilitiesApplication');
     expect(webApplication.operatingSystem).toBe('Any');
     expect(webApplication.inLanguage).toBe('ja');
     expect(webApplication.isAccessibleForFree).toBe(true);

--- a/tests/e2e/specs/webapplication-jsonld.spec.ts
+++ b/tests/e2e/specs/webapplication-jsonld.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+
+type JsonLdObject = Record<string, unknown>;
+
+type WebApplication = JsonLdObject & {
+  '@type': 'WebApplication';
+  name: string;
+  url: string;
+  description: string;
+  applicationCategory: string;
+  operatingSystem: string;
+  inLanguage: string;
+  isAccessibleForFree: boolean;
+  offers: {
+    '@type': 'Offer';
+    price: string;
+    priceCurrency: string;
+  };
+};
+
+const toolPages = [
+  {
+    path: '/calculate-cat-age',
+    name: '猫の年齢計算',
+    url: 'https://cat-tools.catnote.tokyo/calculate-cat-age',
+    description: '誕生日から猫の年齢を人間年齢の目安に換算し、ライフステージも確認できます。',
+    applicationCategory: 'CalculatorApplication',
+    hasFaq: true,
+  },
+  {
+    path: '/calculate-cat-calorie',
+    name: '猫のカロリー計算',
+    url: 'https://cat-tools.catnote.tokyo/calculate-cat-calorie',
+    description: '体重と条件から猫の1日の必要カロリーの目安を計算します。',
+    applicationCategory: 'CalculatorApplication',
+    hasFaq: true,
+  },
+  {
+    path: '/calculate-cat-feeding',
+    name: '猫の給餌量計算',
+    url: 'https://cat-tools.catnote.tokyo/calculate-cat-feeding',
+    description: '1日の必要カロリーとフードのカロリー密度から、1日量と朝夜の目安量を計算します。',
+    applicationCategory: 'CalculatorApplication',
+    hasFaq: false,
+  },
+  {
+    path: '/calculate-cat-water-intake',
+    name: '猫の必要給水量計算',
+    url: 'https://cat-tools.catnote.tokyo/calculate-cat-water-intake',
+    description: '体重とフード量から、総水分目標・食事由来水分・器からの飲水目標を計算します。',
+    applicationCategory: 'CalculatorApplication',
+    hasFaq: true,
+  },
+  {
+    path: '/cat-food-safety',
+    name: '猫の食べ物安全性チェック',
+    url: 'https://cat-tools.catnote.tokyo/cat-food-safety',
+    description: '食材名から猫にとって安全・注意・危険の目安を確認できます。',
+    applicationCategory: 'ReferenceApplication',
+    hasFaq: true,
+  },
+] as const;
+
+function flattenJsonLd(payload: unknown): JsonLdObject[] {
+  if (Array.isArray(payload)) {
+    return payload.flatMap(flattenJsonLd);
+  }
+  if (payload && typeof payload === 'object') {
+    return [payload as JsonLdObject];
+  }
+  return [];
+}
+
+function isWebApplication(value: JsonLdObject): value is WebApplication {
+  return value['@type'] === 'WebApplication';
+}
+
+test.describe('WebApplication JSON-LD', () => {
+  for (const toolPage of toolPages) {
+    test(`${toolPage.path} に統一形式の WebApplication が出力される`, async ({ page }) => {
+      await page.goto(toolPage.path);
+
+      const jsonLdObjects = (
+        await page.locator('script[type="application/ld+json"]').allTextContents()
+      ).flatMap((text) => flattenJsonLd(JSON.parse(text)));
+
+      const webApplications = jsonLdObjects.filter(isWebApplication);
+      expect(webApplications).toHaveLength(1);
+      expect(webApplications[0]).toMatchObject({
+        '@context': 'https://schema.org',
+        '@type': 'WebApplication',
+        name: toolPage.name,
+        url: toolPage.url,
+        description: toolPage.description,
+        applicationCategory: toolPage.applicationCategory,
+        operatingSystem: 'Any',
+        inLanguage: 'ja',
+        isAccessibleForFree: true,
+        offers: {
+          '@type': 'Offer',
+          price: '0',
+          priceCurrency: 'JPY',
+        },
+      });
+      expect(jsonLdObjects.some((item) => item['@type'] === 'BreadcrumbList')).toBe(true);
+      expect(jsonLdObjects.some((item) => item['@type'] === 'FAQPage')).toBe(toolPage.hasFaq);
+    });
+  }
+});

--- a/tests/e2e/specs/webapplication-jsonld.spec.ts
+++ b/tests/e2e/specs/webapplication-jsonld.spec.ts
@@ -24,7 +24,7 @@ const toolPages = [
     name: '猫の年齢計算',
     url: 'https://cat-tools.catnote.tokyo/calculate-cat-age',
     description: '誕生日から猫の年齢を人間年齢の目安に換算し、ライフステージも確認できます。',
-    applicationCategory: 'CalculatorApplication',
+    applicationCategory: 'UtilitiesApplication',
     hasFaq: true,
   },
   {
@@ -32,7 +32,7 @@ const toolPages = [
     name: '猫のカロリー計算',
     url: 'https://cat-tools.catnote.tokyo/calculate-cat-calorie',
     description: '体重と条件から猫の1日の必要カロリーの目安を計算します。',
-    applicationCategory: 'CalculatorApplication',
+    applicationCategory: 'UtilitiesApplication',
     hasFaq: true,
   },
   {
@@ -40,7 +40,7 @@ const toolPages = [
     name: '猫の給餌量計算',
     url: 'https://cat-tools.catnote.tokyo/calculate-cat-feeding',
     description: '1日の必要カロリーとフードのカロリー密度から、1日量と朝夜の目安量を計算します。',
-    applicationCategory: 'CalculatorApplication',
+    applicationCategory: 'UtilitiesApplication',
     hasFaq: false,
   },
   {
@@ -48,7 +48,7 @@ const toolPages = [
     name: '猫の必要給水量計算',
     url: 'https://cat-tools.catnote.tokyo/calculate-cat-water-intake',
     description: '体重とフード量から、総水分目標・食事由来水分・器からの飲水目標を計算します。',
-    applicationCategory: 'CalculatorApplication',
+    applicationCategory: 'UtilitiesApplication',
     hasFaq: true,
   },
   {


### PR DESCRIPTION
## 関連Issue
- Closes #124

## 概要
- 全5ツールページの `WebApplication` JSON-LD を共通形式に統一
- `WebApplication` 生成ヘルパーを追加し、共通フィールドを一元化
- 未実装だった給餌量・給水量・食べ物安全性ページにも `WebApplication` を追加
- 全ツールページの JSON-LD を検証するE2Eを追加

## 今回レビューしてほしい観点
- [x] 正確性（各ページの name/url/description/applicationCategory がIssue要件どおりか）
- [x] 型安全性（共通ヘルパーとE2Eの型整合性）

## スクリーンショット/動画（任意）
- なし（構造化データのみ）

## 動作確認
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run test:e2e -- tests/e2e/specs/webapplication-jsonld.spec.ts tests/e2e/specs/calorie.basic.spec.ts`
- [x] `SITE_URL=https://cat-tools.catnote.tokyo npm run build`

## 影響範囲
- 全ツールページの構造化データ
- カロリーページE2E
- WebApplication JSON-LD E2E

## チェックリスト
- [x] ESLint/Prettier を通過
- [x] テストコード を追加/更新
- [x] 文言・日本語確認

## 備考
- 計算ロジックや画面UIは変更していません。
- 既存の `FAQPage` / `BreadcrumbList` JSON-LD は維持しています。
