### PR TITLE
給餌量・給水量ページに参考情報セクションを追加

### DIFF
--- a/src/app/calculate-cat-water-intake/CatWaterIntakeCalculator.tsx
+++ b/src/app/calculate-cat-water-intake/CatWaterIntakeCalculator.tsx
@@ -161,6 +161,37 @@ function WaterIntakeSupplementaryContent() {
           </ul>
         </div>
       </section>
+
+      <section className="section mt-10" aria-labelledby="water-intake-references">
+        <h2
+          id="water-intake-references"
+          className="my-4 pt-4 font-extrabold text-xl md:text-2xl tracking-tight text-balance"
+        >
+          {supplementaryText.REFERENCES.TITLE}
+        </h2>
+        <div className="space-y-3">
+          {supplementaryText.REFERENCES.BODY.map((paragraph, index) => (
+            <p key={`water-intake-reference-body-${index}`} className="text-sm text-gray-700 leading-relaxed text-pretty">
+              {paragraph}
+            </p>
+          ))}
+        </div>
+        <ul className="list-disc space-y-2 pl-5 text-sm text-gray-700 leading-relaxed mt-4">
+          {supplementaryText.REFERENCES.LINKS.map((source) => (
+            <li key={source.URL}>
+              <a
+                href={source.URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-pink-700 hover:text-pink-800 underline underline-offset-2 break-all"
+              >
+                {source.LABEL}
+              </a>
+              <span className="text-gray-600"> — {source.NOTE}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
     </>
   );
 }

--- a/src/components/CatFeedingCalculator.tsx
+++ b/src/components/CatFeedingCalculator.tsx
@@ -248,6 +248,37 @@ function FeedingSupplementaryContent() {
           </p>
         </div>
       </section>
+
+      <section className="section mt-10" aria-labelledby="feeding-references">
+        <h2
+          id="feeding-references"
+          className="my-4 pt-4 font-extrabold text-xl md:text-2xl tracking-tight text-balance"
+        >
+          {supplementaryText.REFERENCES.TITLE}
+        </h2>
+        <div className="space-y-3">
+          {supplementaryText.REFERENCES.BODY.map((paragraph, index) => (
+            <p key={`feeding-reference-body-${index}`} className="text-sm text-gray-700 leading-relaxed text-pretty">
+              {paragraph}
+            </p>
+          ))}
+        </div>
+        <ul className="list-disc space-y-2 pl-5 text-sm text-gray-700 leading-relaxed mt-4">
+          {supplementaryText.REFERENCES.LINKS.map((source) => (
+            <li key={source.URL}>
+              <a
+                href={source.URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-pink-700 hover:text-pink-800 underline underline-offset-2 break-all"
+              >
+                {source.LABEL}
+              </a>
+              <span className="text-gray-600"> — {source.NOTE}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
     </>
   );
 }

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -944,6 +944,35 @@ export const FEEDING_UI_TEXT = {
       BODY:
         '「必要カロリーを知るページ」と「給餌量をグラムに換算するページ」をあわせて使うことで、毎日の食事管理がしやすくなります。',
     },
+    REFERENCES: {
+      TITLE: '計算方法の参考情報',
+      BODY: [
+        'このページの給餌量計算は、1日の必要カロリーとフードのカロリー密度をもとにグラムへ換算する考え方を採用しています。',
+        'フードのラベル表示や体型変化もあわせて確認し、計算結果を固定値にせず、必要に応じて少しずつ調整してください。',
+      ],
+      LINKS: [
+        {
+          LABEL: 'AAFCO: Reading Labels',
+          URL: 'https://www.aafco.org/consumers/understanding-pet-food/reading-labels/',
+          NOTE: 'ペットフードラベル、給餌量表示、カロリー表示を確認する参考情報',
+        },
+        {
+          LABEL: 'AAFCO: Calorie Content',
+          URL: 'https://www.aafco.org/resources/startups/calorie-content/',
+          NOTE: 'ペットフードのカロリー表示と単位換算を確認する参考情報',
+        },
+        {
+          LABEL: 'WSAVA: Global Nutrition Guidelines',
+          URL: 'https://wsava.org/global-guidelines/global-nutrition-guidelines/',
+          NOTE: 'BCS、栄養評価、個体差を踏まえた調整の参考情報',
+        },
+        {
+          LABEL: 'FelineVMA / AAFP: Feline Feeding Programs',
+          URL: 'https://catvets.com/resource/how-to-feed-how-to-feed-a-cat-consensus-statement/',
+          NOTE: '食事回数、食べ方、環境、複数猫家庭での給餌設計の参考情報',
+        },
+      ],
+    },
     DISCLAIMER:
       'このページの計算結果や説明は、一般的な目安として使える内容をまとめたものです。実際に必要な量は、猫の体格や体調、活動量、食欲によって変わります。急な食欲低下や体重変化がある場合は、計算値だけで判断せず、日々の様子もあわせて確認してください。',
   },
@@ -1144,6 +1173,25 @@ export const WATER_INTAKE_UI_TEXT = {
         '食欲に変化がある',
         '以前より元気がない',
         '毛づやの変化が気になる',
+      ],
+    },
+    REFERENCES: {
+      TITLE: '計算方法の参考情報',
+      BODY: [
+        'このページの給水量計算は、体重あたりの総水分目安と、フードに含まれる水分量を分けて考える構成です。',
+        '表示値は一般的な目安として扱い、普段の飲水傾向や体調変化とあわせて確認してください。',
+      ],
+      LINKS: [
+        {
+          LABEL: 'Merck Veterinary Manual: Nutritional Requirements of Small Animals',
+          URL: 'https://www.merckvetmanual.com/management-and-nutrition/nutrition-small-animals/nutritional-requirements-of-small-animals',
+          NOTE: '犬猫の水分必要量、食事・環境・活動量・健康状態による個体差、ドライ/缶詰フードの水分量差の参考情報',
+        },
+        {
+          LABEL: 'Cornell Feline Health Center: Hydration',
+          URL: 'https://www.vet.cornell.edu/departments-centers-and-institutes/cornell-feline-health-center/health-information/feline-health-topics/hydration',
+          NOTE: '猫の水分摂取、ウェットフードとドライフードによる飲水量差、脱水サインの参考情報',
+        },
       ],
     },
     DISCLAIMER:

--- a/tests/e2e/specs/feeding.spec.ts
+++ b/tests/e2e/specs/feeding.spec.ts
@@ -90,6 +90,7 @@ test.describe('猫の給餌量計算 E2E', () => {
     await expect(page.getByRole('heading', { name: 'ドライフード・ウェットフード・おやつの考え方' })).toBeVisible();
     await expect(page.getByRole('heading', { name: '給餌量の具体例' })).toBeVisible();
     await expect(page.getByRole('heading', { name: '関連ツール' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '計算方法の参考情報' })).toBeVisible();
 
     await expect(page.getByText('ウェットフードだけでも同じように計算できる？')).toBeVisible();
     await expect(page.getByText('フードを変えたら給餌量も変えるべき？')).toBeVisible();
@@ -97,5 +98,23 @@ test.describe('猫の給餌量計算 E2E', () => {
     const relatedToolLink = page.getByRole('link', { name: '猫のカロリー計算ページ' });
     await expect(relatedToolLink).toBeVisible();
     await expect(relatedToolLink).toHaveAttribute('href', '/calculate-cat-calorie');
+
+    const aafcoLabelLink = page.getByRole('link', { name: 'AAFCO: Reading Labels' });
+    await expect(aafcoLabelLink).toHaveAttribute('href', 'https://www.aafco.org/consumers/understanding-pet-food/reading-labels/');
+    await expect(aafcoLabelLink).toHaveAttribute('target', '_blank');
+    await expect(aafcoLabelLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    await expect(page.getByRole('link', { name: 'AAFCO: Calorie Content' })).toHaveAttribute(
+      'href',
+      'https://www.aafco.org/resources/startups/calorie-content/',
+    );
+    await expect(page.getByRole('link', { name: 'WSAVA: Global Nutrition Guidelines' })).toHaveAttribute(
+      'href',
+      'https://wsava.org/global-guidelines/global-nutrition-guidelines/',
+    );
+    await expect(page.getByRole('link', { name: 'FelineVMA / AAFP: Feline Feeding Programs' })).toHaveAttribute(
+      'href',
+      'https://catvets.com/resource/how-to-feed-how-to-feed-a-cat-consensus-statement/',
+    );
   });
 });

--- a/tests/e2e/specs/water-intake.spec.ts
+++ b/tests/e2e/specs/water-intake.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/calculate-cat-water-intake';
+
+test.describe('猫の必要給水量計算 E2E', () => {
+  test('参考情報セクションと外部リンクが表示される', async ({ page }) => {
+    await page.goto(PAGE);
+
+    await expect(page.getByRole('heading', { name: '猫の1日に必要な水分量はどう決まる？' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '水を飲みすぎるときは注意' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '計算方法の参考情報' })).toBeVisible();
+
+    const merckLink = page.getByRole('link', {
+      name: 'Merck Veterinary Manual: Nutritional Requirements of Small Animals',
+    });
+    await expect(merckLink).toHaveAttribute(
+      'href',
+      'https://www.merckvetmanual.com/management-and-nutrition/nutrition-small-animals/nutritional-requirements-of-small-animals',
+    );
+    await expect(merckLink).toHaveAttribute('target', '_blank');
+    await expect(merckLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const cornellLink = page.getByRole('link', { name: 'Cornell Feline Health Center: Hydration' });
+    await expect(cornellLink).toHaveAttribute(
+      'href',
+      'https://www.vet.cornell.edu/departments-centers-and-institutes/cornell-feline-health-center/health-information/feline-health-topics/hydration',
+    );
+    await expect(cornellLink).toHaveAttribute('target', '_blank');
+    await expect(cornellLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});


### PR DESCRIPTION
## 関連Issue
- Closes #125

## 概要
- `/calculate-cat-feeding` に `計算方法の参考情報` セクションを追加
- `/calculate-cat-water-intake` に `計算方法の参考情報` セクションを追加
- 外部参考リンクの表示と `target="_blank"` / `rel="noopener noreferrer"` を E2E で検証

## 今回レビューしてほしい観点
- [x] 正確性（参考情報の位置・文言・リンク先が妥当か）
- [x] 型安全性（TS の型整合性）

## スクリーンショット/動画（任意）
- Playwright MCP で `/calculate-cat-feeding` と `/calculate-cat-water-intake` の full page screenshot を取得して表示崩れがないことを確認済み

## 動作確認
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npx playwright test tests/e2e/specs/feeding.spec.ts tests/e2e/specs/water-intake.spec.ts`
- [x] Playwright MCP で対象ページを表示確認

## 影響範囲
- `/calculate-cat-feeding`
- `/calculate-cat-water-intake`
- SEO向けのページ本文補強（構造化データ・計算ロジック・URLクエリ連携は変更なし）

## チェックリスト
- [x] ESLint/Prettier を通過
- [x] テストコード を追加
- [x] 文言・日本語確認

## 備考
- `更新日` は追加していません
