### PR TITLE
XプロフィールURLをcatnote_tokyoへ更新

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -188,7 +188,7 @@ export default function RootLayout({
                   </li>
                   <li>
                     <a 
-                      href="https://x.com/CATLINK_PR" 
+                      href="https://x.com/catnote_tokyo"
                       target="_blank" 
                       rel="noopener noreferrer"
                       className="hover:text-pink-600 transition-colors"


### PR DESCRIPTION
## 関連Issue
- Closes #133

## 概要
- フッターの SNS リンク先を `https://x.com/CATLINK_PR` から `https://x.com/catnote_tokyo` に更新
- 旧 X プロフィール URL の参照が残っていないことを確認

## 今回レビューしてほしい観点
- [x] 正確性（仕様どおり/バグの有無）

## スクリーンショット/動画（任意）
- Playwright MCP でトップページのフルページキャプチャを取得済み

## 動作確認
- [x] `npm run lint`
- [x] `npm run test`
- [x] Playwright MCP でトップページを表示し、フッターの `SNS` リンクが `https://x.com/catnote_tokyo` であることを確認

## 影響範囲
- `src/app/layout.tsx` のフッター SNS リンク

## チェックリスト
- [x] ESLint/Prettier を通過
- [ ] テストコード を追加（URL差し替えのみのため未追加）
- [x] 文言・日本語確認

## 備考
- `npm ci` 実行時に既存依存関係の audit 警告が表示されましたが、本対応では変更していません。
