### PR TITLE
aboutページのつくし画像をレスポンシブ最適化する

### DIFF
--- a/src/app/about/TsukushiImage.tsx
+++ b/src/app/about/TsukushiImage.tsx
@@ -1,17 +1,15 @@
+import ResponsiveImage from '@/components/ResponsiveImage';
+
 export default function TsukushiImage() {
   return (
     <div className="relative aspect-[4/5] overflow-hidden rounded-lg bg-gray-50">
-      <picture>
-        <source srcSet="/images/about/tsukushi.webp" type="image/webp" />
-        <img
-          src="/images/about/tsukushi.jpg"
-          alt="保護猫のつくし"
-          width={900}
-          height={1125}
-          className="h-full w-full object-cover"
-          loading="lazy"
-        />
-      </picture>
+      <ResponsiveImage
+        src="/images/about/tsukushi.webp"
+        alt="保護猫のつくし"
+        fill
+        sizes="220px"
+        className="object-cover"
+      />
     </div>
   );
 }

--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -1,0 +1,10 @@
+import Image, { type ImageProps } from 'next/image';
+
+type ResponsiveImageProps = Omit<ImageProps, 'alt' | 'sizes'> & {
+  alt: string;
+  sizes: string;
+};
+
+export default function ResponsiveImage({ alt, sizes, ...props }: ResponsiveImageProps) {
+  return <Image {...props} alt={alt} sizes={sizes} />;
+}


### PR DESCRIPTION
## 関連Issue
- Closes #139

## 概要
- `sizes` を必須にした `ResponsiveImage` コンポーネントを追加
- aboutページのつくし画像を `next/image` ベースの配信に変更し、表示幅に応じた派生WebPが返るようにした
- `tsukushi.webp` は `main` に既に存在するため、元画像を再生成せず最適化の入力ソースとして利用

## 今回レビューしてほしい観点
- [x] 正確性（表示幅220pxに対する画像配信の最適化）
- [x] 型安全性（`alt` と `sizes` を必須にしたコンポーネントAPI）

## スクリーンショット/動画（任意）
- ローカルproductionビルドでaboutページをキャプチャし、既存レイアウトを維持していることを確認済み

## 動作確認
- [x] `npm run lint`
- [x] `npm run test -- --runInBand`（75 tests passed）
- [x] `npm run build`
- [x] ローカルproductionビルドでaboutページの表示を確認
- [x] Lighthouse（PC/SP）で `Properly size images` がともに合格 (`score: 1`)
- [x] 配信画像が `/_next/image` 経由のWebPとなり、確認した派生画像が `79,616 bytes` から `22,928 bytes` に縮小されることを確認

## 影響範囲
- `/about` のつくし画像表示
- `src/components/ResponsiveImage.tsx`（今後再利用可能な画像表示コンポーネント）

## チェックリスト
- [x] ESLint を通過
- [ ] テストコードを追加（表示コンポーネント置換のため追加なし、既存テストおよび画面/Lighthouse検証を実施）
- [x] 文言・日本語確認（文言変更なし）

## 備考
- GTM/gtag の負荷は Issue #139 のスコープ外として変更していません。
