### PR TITLE
fix: クエリ変更によるGA4 page_viewの過剰計測を防止

### DIFF
--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -12,7 +12,7 @@ export default function Analytics() {
   const pathname = usePathname();
 
   useEffect(() => {
-    if (!isGAEnabled()) return;
+    if (!isGAEnabled() || !pathname) return;
 
     pageview(pathname);
   }, [pathname]);

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { pageview, isGAEnabled } from '@/lib/gtag';
 
 /**
@@ -10,15 +10,12 @@ import { pageview, isGAEnabled } from '@/lib/gtag';
  */
 export default function Analytics() {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
 
   useEffect(() => {
     if (!isGAEnabled()) return;
 
-    const query = searchParams.toString();
-    const url = query ? `${pathname}?${query}` : pathname;
-    pageview(url);
-  }, [pathname, searchParams]);
+    pageview(pathname);
+  }, [pathname]);
 
   return null;
 }

--- a/tests/components/Analytics.test.tsx
+++ b/tests/components/Analytics.test.tsx
@@ -66,4 +66,12 @@ describe('Analytics', () => {
 
     expect(pageview).not.toHaveBeenCalled();
   });
+
+  it('does not send a pageview when pathname is null', () => {
+    usePathname.mockReturnValue(null);
+
+    render(<Analytics />);
+
+    expect(pageview).not.toHaveBeenCalled();
+  });
 });

--- a/tests/components/Analytics.test.tsx
+++ b/tests/components/Analytics.test.tsx
@@ -4,7 +4,6 @@ import { pageview, isGAEnabled } from '@/lib/gtag';
 
 jest.mock('next/navigation', () => ({
   usePathname: jest.fn(),
-  useSearchParams: jest.fn(),
 }));
 
 jest.mock('@/lib/gtag', () => ({
@@ -12,9 +11,8 @@ jest.mock('@/lib/gtag', () => ({
   isGAEnabled: jest.fn(),
 }));
 
-const { usePathname, useSearchParams } = jest.requireMock('next/navigation') as {
+const { usePathname } = jest.requireMock('next/navigation') as {
   usePathname: jest.Mock;
-  useSearchParams: jest.Mock;
 };
 
 describe('Analytics', () => {
@@ -22,25 +20,50 @@ describe('Analytics', () => {
     jest.clearAllMocks();
     (isGAEnabled as jest.Mock).mockReturnValue(true);
     usePathname.mockReturnValue('/cat-age');
+    window.history.replaceState({}, '', '/cat-age');
   });
 
-  it('sends pathname only when query is empty', () => {
-    useSearchParams.mockReturnValue({
-      toString: () => '',
-    });
+  it('sends the pathname once on initial render', () => {
+    render(<Analytics />);
+
+    expect(pageview).toHaveBeenCalledWith('/cat-age');
+    expect(pageview).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends only the pathname when the initial URL has a query string', () => {
+    window.history.replaceState({}, '', '/cat-age?foo=1&bar=2');
 
     render(<Analytics />);
 
     expect(pageview).toHaveBeenCalledWith('/cat-age');
+    expect(pageview).toHaveBeenCalledTimes(1);
   });
 
-  it('includes ? when query string exists', () => {
-    useSearchParams.mockReturnValue({
-      toString: () => 'foo=1&bar=2',
-    });
+  it('does not send another pageview when only the query string changes', () => {
+    const { rerender } = render(<Analytics />);
+
+    window.history.pushState({}, '', '/cat-age?foo=1');
+    rerender(<Analytics />);
+
+    expect(pageview).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends one pageview when the pathname changes', () => {
+    const { rerender } = render(<Analytics />);
+
+    usePathname.mockReturnValue('/calculate-cat-calorie');
+    rerender(<Analytics />);
+
+    expect(pageview).toHaveBeenNthCalledWith(1, '/cat-age');
+    expect(pageview).toHaveBeenNthCalledWith(2, '/calculate-cat-calorie');
+    expect(pageview).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not send a pageview when GA is disabled', () => {
+    (isGAEnabled as jest.Mock).mockReturnValue(false);
 
     render(<Analytics />);
 
-    expect(pageview).toHaveBeenCalledWith('/cat-age?foo=1&bar=2');
+    expect(pageview).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 関連Issue
- Closes #143

## 概要
- Analyticsのpage_view発火条件からsearchParamsを除外
- GA4へ送信するpage_pathをクエリなしのpathnameに統一
- クエリ付き初回表示、クエリのみの変更、pathname遷移、GA4無効時のテストを追加

## 今回レビューしてほしい観点
- [x] 正確性（初回表示とpathname変更時だけpage_viewが送信されること）
- [x] 型安全性（Next.js navigation hookの利用変更に問題がないこと）

## スクリーンショット/動画（任意）
- 画面表示の変更なし

## 動作確認
- [x] npm run lint
- [x] npm run test -- --runInBand（8 suites / 78 tests）
- [ ] デプロイ後にGA4 DebugViewで送信回数を確認

## 影響範囲
- src/components/Analytics.tsx
- tests/components/Analytics.test.tsx
- URLクエリによるフォーム状態の保存・復元・共有処理には変更なし

## チェックリスト
- [x] ESLintを通過
- [x] テストコードを追加
- [x] 文言・日本語確認

## 備考
- GA4 DebugViewでの確認はデプロイ後に実施が必要です。