### PR TITLE
feat: カロリー計算のGA4ファネルイベントを計測する

### DIFF
--- a/src/app/calculate-cat-calorie/CatCalorieCalculator.tsx
+++ b/src/app/calculate-cat-calorie/CatCalorieCalculator.tsx
@@ -19,6 +19,7 @@ import GuideSection from '@/components/GuideSection';
 import Breadcrumbs from '@/components/Breadcrumbs';
 
 const CAT_CALORIE_TOOL_ID = 'cat_calorie';
+const CALCULATION_COMPLETE_DEBOUNCE_MS = 1000;
 
 const trackRelatedToolClick = (targetTool: string, placement: string) => {
   event({
@@ -346,13 +347,17 @@ export default function CatCalorieCalculator() {
 
     if (lastTrackedCalculationSignatureRef.current === calculationSignature) return;
 
-    lastTrackedCalculationSignatureRef.current = calculationSignature;
-    event({
-      action: 'calculation_complete',
-      params: {
-        tool_id: CAT_CALORIE_TOOL_ID,
-      },
-    });
+    const timer = window.setTimeout(() => {
+      lastTrackedCalculationSignatureRef.current = calculationSignature;
+      event({
+        action: 'calculation_complete',
+        params: {
+          tool_id: CAT_CALORIE_TOOL_ID,
+        },
+      });
+    }, CALCULATION_COMPLETE_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
   }, [result, weight, lifeStage, goal, neutered]);
 
   return (

--- a/src/app/calculate-cat-calorie/CatCalorieCalculator.tsx
+++ b/src/app/calculate-cat-calorie/CatCalorieCalculator.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import { LifeStage, Goal, CatCalorieResult } from '@/types';
 import { calculateCatCalorie } from '@/lib/catCalorie';
+import { event } from '@/lib/gtag';
 import {
   CALCULATE_CAT_AGE_PATH,
   CALCULATE_CAT_FEEDING_PATH,
@@ -14,75 +15,28 @@ import { LIFE_STAGES, GOALS } from '@/constants/options';
 import CalorieInput from '@/components/CalorieInput';
 import CalorieResult from '@/components/CalorieResult';
 import CalorieFAQ from '@/components/CalorieFAQ';
+import GuideSection from '@/components/GuideSection';
 import Breadcrumbs from '@/components/Breadcrumbs';
 
-function CalorieOverviewCard() {
-  return (
-    <section
-      className="mt-10 rounded-2xl border border-pink-100 bg-pink-50/70 p-4 sm:p-5"
-      aria-labelledby="calorie-overview-title"
-    >
-      <h2 id="calorie-overview-title" className="text-base font-bold text-gray-900">
-        {CALORIE_UI_TEXT.OVERVIEW.TITLE}
-      </h2>
-      <ul className="mt-3 flex flex-col gap-2 text-sm text-gray-700 leading-relaxed">
-        {CALORIE_UI_TEXT.OVERVIEW.ITEMS.map((item) => (
-          <li key={item} className="flex gap-2">
-            <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-pink-500" aria-hidden="true" />
-            <span>{item}</span>
-          </li>
-        ))}
-      </ul>
-      <div className="mt-3 border-t border-pink-100 pt-3">
-        <h3 className="text-sm font-bold text-gray-900">{CALORIE_UI_TEXT.OVERVIEW.USAGE_TITLE}</h3>
-        <p className="mt-1 text-sm text-gray-700 leading-relaxed text-pretty">
-          {CALORIE_UI_TEXT.OVERVIEW.USAGE_DESCRIPTION}
-        </p>
-      </div>
-    </section>
-  );
-}
+const CAT_CALORIE_TOOL_ID = 'cat_calorie';
 
-function CalorieNextActions({ isVisible }: { isVisible: boolean }) {
-  if (!isVisible) return null;
-
-  return (
-    <section className="section mt-6" aria-labelledby="calorie-next-actions">
-      <div className="rounded-2xl border border-pink-100 bg-white p-4 sm:p-5 shadow-sm">
-        <h2 id="calorie-next-actions" className="text-base font-bold text-gray-900">
-          {CALORIE_UI_TEXT.NEXT_ACTIONS.TITLE}
-        </h2>
-        <div className="mt-3 grid gap-3 sm:grid-cols-2">
-          <div>
-            <p className="text-sm text-gray-700 leading-relaxed">
-              {CALORIE_UI_TEXT.NEXT_ACTIONS.FEEDING.DESCRIPTION}
-            </p>
-            <Link href={CALCULATE_CAT_FEEDING_PATH} className="mt-2 inline-block text-sm font-bold text-pink-600">
-              {CALORIE_UI_TEXT.NEXT_ACTIONS.FEEDING.LABEL}
-            </Link>
-          </div>
-          <div className="border-t border-pink-100 pt-3 sm:border-l sm:border-t-0 sm:pl-4 sm:pt-0">
-            <p className="text-sm text-gray-700 leading-relaxed">
-              {CALORIE_UI_TEXT.NEXT_ACTIONS.AGE.DESCRIPTION}
-            </p>
-            <Link href={CALCULATE_CAT_AGE_PATH} className="mt-2 inline-block text-sm font-bold text-pink-600">
-              {CALORIE_UI_TEXT.NEXT_ACTIONS.AGE.LABEL}
-            </Link>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
+const trackRelatedToolClick = (targetTool: string, placement: string) => {
+  event({
+    action: 'related_tool_click',
+    params: {
+      source_tool: CAT_CALORIE_TOOL_ID,
+      target_tool: targetTool,
+      placement,
+    },
+  });
+};
 
 function CalorieSupplementaryContent() {
   const supplementaryText = CALORIE_UI_TEXT.SUPPLEMENTARY;
 
   return (
     <>
-      <CalorieOverviewCard />
-
-      <section className="section mt-8" aria-labelledby="calorie-result-guide">
+      <section className="section mt-10" aria-labelledby="calorie-result-guide">
         <h2
           id="calorie-result-guide"
           className="my-4 pt-4 font-extrabold text-xl md:text-2xl tracking-tight text-balance"
@@ -123,7 +77,11 @@ function CalorieSupplementaryContent() {
         </div>
         <p className="mt-5 text-sm text-gray-700 leading-relaxed text-pretty">
           {supplementaryText.BASICS.AGE_LINK.TEXT_BEFORE}
-          <Link href={CALCULATE_CAT_AGE_PATH} className="text-pink-600 font-bold">
+          <Link
+            href={CALCULATE_CAT_AGE_PATH}
+            className="text-pink-600 font-bold"
+            onClick={() => trackRelatedToolClick('cat_age', 'basics_age_link')}
+          >
             {supplementaryText.BASICS.AGE_LINK.LABEL}
           </Link>
           {supplementaryText.BASICS.AGE_LINK.TEXT_AFTER}
@@ -148,7 +106,11 @@ function CalorieSupplementaryContent() {
               {index === 1 && (
                 <p className="mt-2 text-sm text-gray-700 leading-relaxed text-pretty">
                   {supplementaryText.FEEDING_STEPS.FEEDING_LINK.TEXT_BEFORE}
-                  <Link href={CALCULATE_CAT_FEEDING_PATH} className="text-pink-600 font-bold">
+                  <Link
+                    href={CALCULATE_CAT_FEEDING_PATH}
+                    className="text-pink-600 font-bold"
+                    onClick={() => trackRelatedToolClick('cat_feeding', 'feeding_steps_feeding_link')}
+                  >
                     {supplementaryText.FEEDING_STEPS.FEEDING_LINK.LABEL}
                   </Link>
                   {supplementaryText.FEEDING_STEPS.FEEDING_LINK.TEXT_AFTER}
@@ -159,7 +121,11 @@ function CalorieSupplementaryContent() {
         </div>
         <p className="mt-5 text-sm text-gray-700 leading-relaxed text-pretty">
           {supplementaryText.FEEDING_STEPS.WATER_INTAKE_LINK.TEXT_BEFORE}
-          <Link href={CALCULATE_CAT_WATER_INTAKE_PATH} className="text-pink-600 font-bold">
+          <Link
+            href={CALCULATE_CAT_WATER_INTAKE_PATH}
+            className="text-pink-600 font-bold"
+            onClick={() => trackRelatedToolClick('cat_water_intake', 'feeding_steps_water_intake_link')}
+          >
             {supplementaryText.FEEDING_STEPS.WATER_INTAKE_LINK.LABEL}
           </Link>
           {supplementaryText.FEEDING_STEPS.WATER_INTAKE_LINK.TEXT_AFTER}
@@ -240,6 +206,7 @@ export default function CatCalorieCalculator() {
   const [neutered, setNeutered] = useState(true);
   const [result, setResult] = useState<CatCalorieResult | null>(null);
   const [error, setError] = useState('');
+  const lastTrackedCalculationSignatureRef = useRef<string | null>(null);
 
   
 
@@ -367,6 +334,27 @@ export default function CatCalorieCalculator() {
     }
   }, [weight, lifeStage, goal, neutered, syncURL]);
 
+  useEffect(() => {
+    if (!result) return;
+
+    const calculationSignature = [
+      weight.trim(),
+      lifeStage,
+      goal,
+      neutered ? '1' : '0',
+    ].join('|');
+
+    if (lastTrackedCalculationSignatureRef.current === calculationSignature) return;
+
+    lastTrackedCalculationSignatureRef.current = calculationSignature;
+    event({
+      action: 'calculation_complete',
+      params: {
+        tool_id: CAT_CALORIE_TOOL_ID,
+      },
+    });
+  }, [result, weight, lifeStage, goal, neutered]);
+
   return (
     <main className="container max-w-3xl mx-auto px-6 pb-10">
       <Breadcrumbs
@@ -408,12 +396,19 @@ export default function CatCalorieCalculator() {
         isVisible={!!result}
         shareUrl={typeof window !== 'undefined' ? buildShareUrl() : undefined}
       />
-      <CalorieNextActions isVisible={!!result} />
 
       <CalorieSupplementaryContent />
 
       {/* FAQ Section */}
       <CalorieFAQ />
+
+      <GuideSection
+        className="mt-8"
+        whatTitle={CALORIE_UI_TEXT.GUIDE.WHAT_TITLE}
+        whatDescription={CALORIE_UI_TEXT.GUIDE.WHAT_DESCRIPTION}
+        usageTitle={CALORIE_UI_TEXT.GUIDE.USAGE_TITLE}
+        usageItems={CALORIE_UI_TEXT.GUIDE.USAGE_ITEMS}
+      />
 
       <section className="section mt-8" aria-label="免責事項">
         <p className="text-sm text-gray-600 leading-relaxed text-pretty">

--- a/src/components/CalorieResult.tsx
+++ b/src/components/CalorieResult.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { CatCalorieResult } from '@/types';
 import { CALORIE_UI_TEXT } from '@/constants/text';
+import { event } from '@/lib/gtag';
 import ShareMenu from './ShareMenu';
+import type { ShareMethod } from './ShareMenu';
 
 interface CalorieResultProps {
   result: CatCalorieResult | null;
@@ -16,6 +18,16 @@ export default function CalorieResult({ result, isVisible, shareUrl }: CalorieRe
     if (!result) return '';
     return CALORIE_UI_TEXT.SHARE.SHARE_TEXT(result.kcal.toString(), result.range);
   }, [result]);
+
+  const handleShareSuccess = useCallback((method: ShareMethod) => {
+    event({
+      action: 'share',
+      params: {
+        tool_id: 'cat_calorie',
+        method,
+      },
+    });
+  }, []);
 
   if (!isVisible || !result) return null;
 
@@ -46,6 +58,7 @@ export default function CalorieResult({ result, isVisible, shareUrl }: CalorieRe
           menuId="shareMenu"
           buttonClassName="absolute right-0 top-0 -translate-y-3/5"
           menuClassName="top-12 border-gray-300 min-w-[220px]"
+          onShareSuccess={handleShareSuccess}
         />
 
         {/* モバイルでは縦並び、PCでは横並び */}

--- a/src/components/ShareMenu.tsx
+++ b/src/components/ShareMenu.tsx
@@ -5,6 +5,8 @@ import { SHARE_UI_TEXT } from '@/constants/text';
 import { IoShareOutline, IoLinkOutline } from 'react-icons/io5';
 import { FaXTwitter } from 'react-icons/fa6';
 
+export type ShareMethod = 'native' | 'copy_link' | 'x';
+
 interface ShareMenuProps {
   shareText: string;
   shareUrl?: string;
@@ -13,6 +15,7 @@ interface ShareMenuProps {
   menuClassName?: string;
   buttonId?: string;
   menuId?: string;
+  onShareSuccess?: (method: ShareMethod) => void;
 }
 
 const TOAST_DURATION_MS = 1600;
@@ -29,6 +32,7 @@ export default function ShareMenu({
   menuClassName,
   buttonId,
   menuId,
+  onShareSuccess,
 }: ShareMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [showToast, setShowToast] = useState(false);
@@ -67,12 +71,13 @@ export default function ShareMenu({
         text: shareText,
         url: resolvedShareUrl || undefined,
       });
+      onShareSuccess?.('native');
     } catch {
       // ignore cancellation
     } finally {
       toggleShare(false);
     }
-  }, [resolvedShareTitle, shareText, resolvedShareUrl, toggleShare]);
+  }, [resolvedShareTitle, shareText, resolvedShareUrl, toggleShare, onShareSuccess]);
 
   const handleCopyLink = useCallback(async () => {
     const target = resolvedShareUrl;
@@ -89,6 +94,7 @@ export default function ShareMenu({
         throw new Error('Clipboard API not available');
       }
       await navigator.clipboard.writeText(target);
+      onShareSuccess?.('copy_link');
       setToastMessage(SHARE_UI_TEXT.TOAST.SUCCESS);
     } catch (error) {
       console.error('Failed to copy link:', error);
@@ -97,7 +103,7 @@ export default function ShareMenu({
       setShowToast(true);
       toggleShare(false);
     }
-  }, [resolvedShareUrl, toggleShare]);
+  }, [resolvedShareUrl, toggleShare, onShareSuccess]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -179,7 +185,10 @@ export default function ShareMenu({
             rel="noopener noreferrer"
             role="menuitem"
             className="share-item flex items-center gap-2.5 w-full px-3 py-2.5 rounded-lg bg-white text-gray-900 cursor-pointer hover:bg-gray-50"
-            onClick={() => toggleShare(false)}
+            onClick={() => {
+              onShareSuccess?.('x');
+              toggleShare(false);
+            }}
           >
             <FaXTwitter className="w-[18px] h-[18px]" aria-hidden="true" />
             <span>{SHARE_UI_TEXT.MENU_ITEMS.X_SHARE}</span>

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -8,13 +8,15 @@ type GtagConfigParams = {
   event_category?: string;
   event_label?: string;
   value?: number;
+  [key: string]: string | number | boolean | undefined;
 };
 
 type GtagEventParams = {
   action: string;
-  category: string;
+  category?: string;
   label?: string;
   value?: number;
+  params?: Record<string, string | number | boolean | undefined>;
 };
 
 // GA4測定ID
@@ -33,8 +35,9 @@ const sendPageview = (url: string) => {
   });
 };
 
-const sendEvent = ({ action, category, label, value }: GtagEventParams) => {
+const sendEvent = ({ action, category, label, value, params }: GtagEventParams) => {
   window.gtag('event', action, {
+    ...params,
     event_category: category,
     event_label: label,
     value: value,
@@ -81,10 +84,10 @@ export const pageview = (url: string) => {
 };
 
 // イベントをトラッキング
-export const event = ({ action, category, label, value }: GtagEventParams) => {
+export const event = ({ action, category, label, value, params }: GtagEventParams) => {
   if (!isGAEnabled()) return;
 
-  const eventParams = { action, category, label, value };
+  const eventParams = { action, category, label, value, params };
   if (!hasGtag()) {
     queuedEvents.push(eventParams);
     return;

--- a/tests/components/CatCalorieCalculator.analytics.test.tsx
+++ b/tests/components/CatCalorieCalculator.analytics.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import CatCalorieCalculator from '@/app/calculate-cat-calorie/CatCalorieCalculator';
+import { event } from '@/lib/gtag';
+
+jest.mock('@/lib/gtag', () => ({
+  event: jest.fn(),
+}));
+
+describe('CatCalorieCalculator analytics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.replaceState({}, '', '/calculate-cat-calorie');
+  });
+
+  it('sends calculation_complete once when a valid result is shown', async () => {
+    const { rerender } = render(<CatCalorieCalculator />);
+
+    fireEvent.change(screen.getByLabelText('体重(kg)'), {
+      target: { value: '4.2' },
+    });
+
+    await waitFor(() => {
+      expect(event).toHaveBeenCalledWith({
+        action: 'calculation_complete',
+        params: {
+          tool_id: 'cat_calorie',
+        },
+      });
+    });
+
+    expect(event).toHaveBeenCalledTimes(1);
+
+    rerender(<CatCalorieCalculator />);
+
+    expect(event).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send calculation_complete when input is invalid', async () => {
+    render(<CatCalorieCalculator />);
+
+    fireEvent.change(screen.getByLabelText('体重(kg)'), {
+      target: { value: '0.1' },
+    });
+
+    await screen.findByRole('alert');
+
+    expect(event).not.toHaveBeenCalled();
+  });
+
+  it('sends related_tool_click for in-page related tool links', () => {
+    render(<CatCalorieCalculator />);
+
+    fireEvent.click(screen.getByRole('link', { name: '猫の給餌量計算ページ' }));
+
+    expect(event).toHaveBeenCalledTimes(1);
+    expect(event).toHaveBeenCalledWith({
+      action: 'related_tool_click',
+      params: {
+        source_tool: 'cat_calorie',
+        target_tool: 'cat_feeding',
+        placement: 'feeding_steps_feeding_link',
+      },
+    });
+  });
+});

--- a/tests/components/CatCalorieCalculator.analytics.test.tsx
+++ b/tests/components/CatCalorieCalculator.analytics.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import CatCalorieCalculator from '@/app/calculate-cat-calorie/CatCalorieCalculator';
 import { event } from '@/lib/gtag';
 
@@ -9,25 +9,53 @@ jest.mock('@/lib/gtag', () => ({
 describe('CatCalorieCalculator analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
     window.history.replaceState({}, '', '/calculate-cat-calorie');
   });
 
-  it('sends calculation_complete once when a valid result is shown', async () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('debounces continuous input and sends calculation_complete once', () => {
     const { rerender } = render(<CatCalorieCalculator />);
+
+    fireEvent.change(screen.getByLabelText('体重(kg)'), {
+      target: { value: '4' },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    fireEvent.change(screen.getByLabelText('体重(kg)'), {
+      target: { value: '4.' },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
 
     fireEvent.change(screen.getByLabelText('体重(kg)'), {
       target: { value: '4.2' },
     });
 
-    await waitFor(() => {
-      expect(event).toHaveBeenCalledWith({
-        action: 'calculation_complete',
-        params: {
-          tool_id: 'cat_calorie',
-        },
-      });
+    act(() => {
+      jest.advanceTimersByTime(999);
     });
 
+    expect(event).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(event).toHaveBeenCalledWith({
+      action: 'calculation_complete',
+      params: {
+        tool_id: 'cat_calorie',
+      },
+    });
     expect(event).toHaveBeenCalledTimes(1);
 
     rerender(<CatCalorieCalculator />);
@@ -35,14 +63,18 @@ describe('CatCalorieCalculator analytics', () => {
     expect(event).toHaveBeenCalledTimes(1);
   });
 
-  it('does not send calculation_complete when input is invalid', async () => {
+  it('does not send calculation_complete when input is invalid', () => {
     render(<CatCalorieCalculator />);
 
     fireEvent.change(screen.getByLabelText('体重(kg)'), {
       target: { value: '0.1' },
     });
 
-    await screen.findByRole('alert');
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
 
     expect(event).not.toHaveBeenCalled();
   });

--- a/tests/components/ShareMenu.test.tsx
+++ b/tests/components/ShareMenu.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ShareMenu from '@/components/ShareMenu';
+
+describe('ShareMenu analytics hooks', () => {
+  const originalShare = navigator.share;
+  const originalClipboard = navigator.clipboard;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: originalShare,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    });
+  });
+
+  it('does not report share when the menu only opens', async () => {
+    const user = userEvent.setup();
+    const onShareSuccess = jest.fn();
+
+    render(
+      <ShareMenu
+        shareText="share text"
+        shareUrl="https://example.com"
+        onShareSuccess={onShareSuccess}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '共有メニューを開く' }));
+
+    expect(onShareSuccess).not.toHaveBeenCalled();
+  });
+
+  it('reports native share only after navigator.share succeeds', async () => {
+    const user = userEvent.setup();
+    const onShareSuccess = jest.fn();
+
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: jest.fn().mockResolvedValue(undefined),
+    });
+
+    render(
+      <ShareMenu
+        shareText="share text"
+        shareUrl="https://example.com"
+        onShareSuccess={onShareSuccess}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '共有メニューを開く' }));
+    await user.click(screen.getByRole('menuitem', { name: '共有する' }));
+
+    expect(onShareSuccess).toHaveBeenCalledTimes(1);
+    expect(onShareSuccess).toHaveBeenCalledWith('native');
+  });
+
+  it('does not report native share when navigator.share is cancelled or fails', async () => {
+    const user = userEvent.setup();
+    const onShareSuccess = jest.fn();
+
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: jest.fn().mockRejectedValue(new Error('cancelled')),
+    });
+
+    render(
+      <ShareMenu
+        shareText="share text"
+        shareUrl="https://example.com"
+        onShareSuccess={onShareSuccess}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '共有メニューを開く' }));
+    await user.click(screen.getByRole('menuitem', { name: '共有する' }));
+
+    expect(onShareSuccess).not.toHaveBeenCalled();
+  });
+
+  it('reports copy link only after clipboard write succeeds', async () => {
+    const user = userEvent.setup();
+    const onShareSuccess = jest.fn();
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    render(
+      <ShareMenu
+        shareText="share text"
+        shareUrl="https://example.com"
+        onShareSuccess={onShareSuccess}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '共有メニューを開く' }));
+    await user.click(screen.getByRole('menuitem', { name: 'リンクをコピー' }));
+
+    expect(onShareSuccess).toHaveBeenCalledTimes(1);
+    expect(onShareSuccess).toHaveBeenCalledWith('copy_link');
+  });
+
+  it('does not report copy link when clipboard write fails', async () => {
+    const user = userEvent.setup();
+    const onShareSuccess = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: jest.fn().mockRejectedValue(new Error('copy failed')),
+      },
+    });
+
+    render(
+      <ShareMenu
+        shareText="share text"
+        shareUrl="https://example.com"
+        onShareSuccess={onShareSuccess}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '共有メニューを開く' }));
+    await user.click(screen.getByRole('menuitem', { name: 'リンクをコピー' }));
+
+    expect(onShareSuccess).not.toHaveBeenCalled();
+  });
+
+  it('reports X share on click as share intent', async () => {
+    const user = userEvent.setup();
+    const onShareSuccess = jest.fn();
+
+    render(
+      <ShareMenu
+        shareText="share text"
+        shareUrl="https://example.com"
+        onShareSuccess={onShareSuccess}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '共有メニューを開く' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Xでシェア' }));
+
+    expect(onShareSuccess).toHaveBeenCalledTimes(1);
+    expect(onShareSuccess).toHaveBeenCalledWith('x');
+  });
+});

--- a/tests/unit/lib/gtag.test.ts
+++ b/tests/unit/lib/gtag.test.ts
@@ -71,4 +71,28 @@ describe('gtag utilities', () => {
       value: 1,
     });
   });
+
+  it('sends GA4 custom event parameters', async () => {
+    const { event, GA_MEASUREMENT_ID } = await import('@/lib/gtag');
+    const gtagMock = jest.fn();
+    window.gtag = gtagMock;
+
+    event({
+      action: 'calculation_complete',
+      params: {
+        tool_id: 'cat_calorie',
+        method: 'copy_link',
+      },
+    });
+
+    expect(gtagMock).toHaveBeenCalledTimes(1);
+    expect(gtagMock).toHaveBeenCalledWith('event', 'calculation_complete', {
+      tool_id: 'cat_calorie',
+      method: 'copy_link',
+      event_category: undefined,
+      event_label: undefined,
+      value: undefined,
+    });
+    expect(GA_MEASUREMENT_ID).toBe('G-TEST123');
+  });
 });


### PR DESCRIPTION
## 概要

- カロリー計算ページで `calculation_complete` / `related_tool_click` / `share` のGA4イベントを送信するようにしました
- `gtag.event()` で GA4 カスタムパラメータを扱えるように拡張しました
- 共有は成功時のみ計測し、X共有はクリック時点の共有意図として計測します
- Issue #145 の受け入れ条件に対応するコンポーネント/ユニットテストを追加しました

## 対応Issue

Closes #145

## スコープ

- 対象: `/calculate-cat-calorie`
- GA4パラメータ:
  - `tool_id`
  - `source_tool`
  - `target_tool`
  - `placement`
  - `method`

## スコープ外

- GA4側のカスタムディメンション登録
- GA4キーイベント化
- GA4探索レポート作成
- CTA/UI導線改善
- 他ツールへの横展開

## 検証

- [x] `npm run lint`
- [x] `npm run test`

## 補足

本番反映前に、GA4側でイベントスコープのカスタムディメンションを登録してください。
