### PR TITLE
feat: カロリー計算結果直後に給餌量CTAを追加する

### DIFF
--- a/src/components/CalorieResult.tsx
+++ b/src/components/CalorieResult.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useCallback, useMemo } from 'react';
+import Link from 'next/link';
 import { CatCalorieResult } from '@/types';
 import { CALORIE_UI_TEXT } from '@/constants/text';
+import { CALCULATE_CAT_FEEDING_PATH } from '@/constants/paths';
 import { event } from '@/lib/gtag';
 import ShareMenu from './ShareMenu';
 import type { ShareMethod } from './ShareMenu';
@@ -29,7 +31,20 @@ export default function CalorieResult({ result, isVisible, shareUrl }: CalorieRe
     });
   }, []);
 
+  const handleFeedingClick = useCallback(() => {
+    event({
+      action: 'related_tool_click',
+      params: {
+        source_tool: 'cat_calorie',
+        target_tool: 'cat_feeding',
+        placement: 'calorie_result_cta',
+      },
+    });
+  }, []);
+
   if (!isVisible || !result) return null;
+
+  const feedingHref = `${CALCULATE_CAT_FEEDING_PATH}?kcal=${encodeURIComponent(result.kcal.toString())}`;
 
   return (
     <section className="section mt-10" aria-live="polite">
@@ -95,6 +110,22 @@ export default function CalorieResult({ result, isVisible, shareUrl }: CalorieRe
               {result.note}
             </div>
           </div>
+        </div>
+
+        <div className="mt-8 rounded-2xl border border-pink-200 bg-pink-50 p-5 text-left">
+          <p className="text-sm font-bold text-pink-700">
+            {CALORIE_UI_TEXT.NEXT_ACTIONS.TITLE}
+          </p>
+          <p className="mt-2 text-sm leading-relaxed text-gray-700">
+            {CALORIE_UI_TEXT.NEXT_ACTIONS.FEEDING.DESCRIPTION}
+          </p>
+          <Link
+            href={feedingHref}
+            onClick={handleFeedingClick}
+            className="mt-4 inline-flex w-full items-center justify-center rounded-xl bg-pink-600 px-5 py-3 text-center text-sm font-bold text-white transition-colors hover:bg-pink-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-600 focus-visible:ring-offset-2"
+          >
+            {CALORIE_UI_TEXT.NEXT_ACTIONS.FEEDING.LABEL}
+          </Link>
         </div>
       </div>
     </section>

--- a/tests/components/CatCalorieCalculator.analytics.test.tsx
+++ b/tests/components/CatCalorieCalculator.analytics.test.tsx
@@ -79,6 +79,41 @@ describe('CatCalorieCalculator analytics', () => {
     expect(event).not.toHaveBeenCalled();
   });
 
+  it('shows the result CTA with kcal and sends related_tool_click', () => {
+    render(<CatCalorieCalculator />);
+
+    expect(
+      screen.queryByRole('link', {
+        name: '猫の給餌量計算で、1日に与えるグラム数を確認する',
+      }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('体重(kg)'), {
+      target: { value: '4.2' },
+    });
+
+    const resultCta = screen.getByRole('link', {
+      name: '猫の給餌量計算で、1日に与えるグラム数を確認する',
+    });
+
+    expect(resultCta).toHaveAttribute(
+      'href',
+      '/calculate-cat-feeding?kcal=246.4',
+    );
+
+    fireEvent.click(resultCta);
+
+    expect(event).toHaveBeenCalledTimes(1);
+    expect(event).toHaveBeenCalledWith({
+      action: 'related_tool_click',
+      params: {
+        source_tool: 'cat_calorie',
+        target_tool: 'cat_feeding',
+        placement: 'calorie_result_cta',
+      },
+    });
+  });
+
   it('sends related_tool_click for in-page related tool links', () => {
     render(<CatCalorieCalculator />);
 

--- a/tests/e2e/specs/calorie.feeding-cta.spec.ts
+++ b/tests/e2e/specs/calorie.feeding-cta.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+const CTA_LABEL = '猫の給餌量計算で、1日に与えるグラム数を確認する';
+
+test.describe('カロリー計算結果の給餌量CTA', () => {
+  test('計算結果のkcalを給餌量計算へ引き継ぐ', async ({ page }) => {
+    await page.goto('/calculate-cat-calorie');
+
+    const cta = page.getByRole('link', { name: CTA_LABEL });
+    await expect(cta).toHaveCount(0);
+
+    await page.fill('#weight', '4.2');
+
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute(
+      'href',
+      '/calculate-cat-feeding?kcal=246.4',
+    );
+
+    await cta.click();
+
+    await expect(page).toHaveURL(/\/calculate-cat-feeding\?kcal=246\.4$/);
+    await expect(page.locator('#kcalInput')).toHaveValue('246.4');
+    await expect(page.locator('#densityInput')).toHaveValue('');
+  });
+});


### PR DESCRIPTION
## 関連Issue
- Closes #148

## 概要
- カロリー計算結果の直後に、給餌量計算へ進むCTAを追加
- 計算済みkcalを `/calculate-cat-feeding?kcal=<計算結果>` で引き継ぎ
- CTAクリック時に既存の `related_tool_click` を `placement: calorie_result_cta` で送信
- CTAの表示・URL・GA4イベントと、給餌量画面への値引き継ぎをテスト

## 今回レビューしてほしい観点
- [x] 正確性（結果表示時のみCTAが表示され、計算中のkcalが引き継がれること）
- [x] 型安全性（既存の定数・イベント送信APIを利用していること）

## スクリーンショット/動画（任意）
- ローカルでデスクトップ幅・モバイル幅の表示崩れがないことを確認済み

## 動作確認
- [x] デスクトップChromiumで表示・遷移を確認
- [x] スマホ幅Chromiumで表示・遷移を確認
- [x] `npm run lint`
- [x] `npm run test -- --runInBand`（90件成功）
- [x] `SITE_URL=https://cat-tools.catnote.tokyo npm run build`
- [x] `npx playwright test`（デスクトップ・モバイル計266件成功）

## 影響範囲
- 猫のカロリー計算結果UI
- 猫の給餌量計算への遷移URL
- GA4 `related_tool_click` の送信箇所
- カロリー計算の単体テスト・E2Eテスト

## チェックリスト
- [x] ESLintを通過
- [x] テストコードを追加
- [x] 文言・日本語確認

## 備考
- 本文下部の既存給餌量リンクと `feeding_steps_feeding_link` 計測は維持しています。
- 新規GA4イベント、給餌量側の計算完了イベント、A/Bテスト、28日後の効果検証は対象外です。