### PR TITLE
fix: 初回 page_view をGA4初期化時に送信

### DIFF
--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,18 +1,25 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { usePathname } from 'next/navigation';
 import { pageview, isGAEnabled } from '@/lib/gtag';
 
 /**
  * Google Analytics ページビュー追跡コンポーネント
- * App Routerでのクライアントサイドナビゲーションを追跡
+ * 初回ページビューはGoogleAnalyticsScriptに任せ、
+ * App Routerでのクライアントサイドナビゲーションのみ追跡する
  */
 export default function Analytics() {
   const pathname = usePathname();
+  const previousPathname = useRef(pathname);
 
   useEffect(() => {
-    if (!isGAEnabled() || !pathname) return;
+    if (!pathname) return;
+
+    const previousPath = previousPathname.current;
+    previousPathname.current = pathname;
+
+    if (!isGAEnabled() || !previousPath || previousPath === pathname) return;
 
     pageview(pathname);
   }, [pathname]);

--- a/src/components/GoogleAnalyticsScript.tsx
+++ b/src/components/GoogleAnalyticsScript.tsx
@@ -13,9 +13,7 @@ export default function GoogleAnalyticsScript() {
           window.dataLayer = window.dataLayer || [];
           window.gtag = window.gtag || function(){window.dataLayer.push(arguments);};
           window.gtag('js', new Date());
-          window.gtag('config', '${GA_MEASUREMENT_ID}', {
-            send_page_view: false,
-          });
+          window.gtag('config', '${GA_MEASUREMENT_ID}');
         `}
       </Script>
       <Script

--- a/tests/components/Analytics.test.tsx
+++ b/tests/components/Analytics.test.tsx
@@ -23,20 +23,18 @@ describe('Analytics', () => {
     window.history.replaceState({}, '', '/cat-age');
   });
 
-  it('sends the pathname once on initial render', () => {
+  it('does not send a pageview on initial render', () => {
     render(<Analytics />);
 
-    expect(pageview).toHaveBeenCalledWith('/cat-age');
-    expect(pageview).toHaveBeenCalledTimes(1);
+    expect(pageview).not.toHaveBeenCalled();
   });
 
-  it('sends only the pathname when the initial URL has a query string', () => {
+  it('does not send a pageview when the initial URL has a query string', () => {
     window.history.replaceState({}, '', '/cat-age?foo=1&bar=2');
 
     render(<Analytics />);
 
-    expect(pageview).toHaveBeenCalledWith('/cat-age');
-    expect(pageview).toHaveBeenCalledTimes(1);
+    expect(pageview).not.toHaveBeenCalled();
   });
 
   it('does not send another pageview when only the query string changes', () => {
@@ -45,7 +43,7 @@ describe('Analytics', () => {
     window.history.pushState({}, '', '/cat-age?foo=1');
     rerender(<Analytics />);
 
-    expect(pageview).toHaveBeenCalledTimes(1);
+    expect(pageview).not.toHaveBeenCalled();
   });
 
   it('sends one pageview when the pathname changes', () => {
@@ -54,15 +52,17 @@ describe('Analytics', () => {
     usePathname.mockReturnValue('/calculate-cat-calorie');
     rerender(<Analytics />);
 
-    expect(pageview).toHaveBeenNthCalledWith(1, '/cat-age');
-    expect(pageview).toHaveBeenNthCalledWith(2, '/calculate-cat-calorie');
-    expect(pageview).toHaveBeenCalledTimes(2);
+    expect(pageview).toHaveBeenCalledWith('/calculate-cat-calorie');
+    expect(pageview).toHaveBeenCalledTimes(1);
   });
 
-  it('does not send a pageview when GA is disabled', () => {
+  it('does not send a pageview on pathname changes when GA is disabled', () => {
     (isGAEnabled as jest.Mock).mockReturnValue(false);
 
-    render(<Analytics />);
+    const { rerender } = render(<Analytics />);
+
+    usePathname.mockReturnValue('/calculate-cat-calorie');
+    rerender(<Analytics />);
 
     expect(pageview).not.toHaveBeenCalled();
   });
@@ -71,6 +71,16 @@ describe('Analytics', () => {
     usePathname.mockReturnValue(null);
 
     render(<Analytics />);
+
+    expect(pageview).not.toHaveBeenCalled();
+  });
+
+  it('does not send a pageview when the initial null pathname resolves', () => {
+    usePathname.mockReturnValue(null);
+    const { rerender } = render(<Analytics />);
+
+    usePathname.mockReturnValue('/cat-age');
+    rerender(<Analytics />);
 
     expect(pageview).not.toHaveBeenCalled();
   });

--- a/tests/components/GoogleAnalyticsScript.test.tsx
+++ b/tests/components/GoogleAnalyticsScript.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import GoogleAnalyticsScript from '@/components/GoogleAnalyticsScript';
+import { flushQueuedEvents, flushQueuedPageviews } from '@/lib/gtag';
+
+jest.mock('next/script', () => ({
+  __esModule: true,
+  default: ({ children, id, onLoad }: { children?: ReactNode; id?: string; onLoad?: () => void }) => (
+    <button id={id} onClick={onLoad}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@/lib/gtag', () => ({
+  flushQueuedEvents: jest.fn(),
+  flushQueuedPageviews: jest.fn(),
+  GA_MEASUREMENT_ID: 'G-TEST123',
+}));
+
+describe('GoogleAnalyticsScript', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('enables the initial automatic pageview in the first config command', () => {
+    const { container } = render(<GoogleAnalyticsScript />);
+    const initScript = container.querySelector('#ga4-init');
+
+    expect(initScript).toHaveTextContent("window.gtag('config', 'G-TEST123');");
+    expect(initScript).not.toHaveTextContent('send_page_view: false');
+  });
+
+  it('flushes queued pageviews before queued custom events', () => {
+    const { container } = render(<GoogleAnalyticsScript />);
+    const externalScript = container.querySelector('#ga4-script');
+
+    expect(externalScript).not.toBeNull();
+    fireEvent.click(externalScript!);
+
+    expect(flushQueuedPageviews).toHaveBeenCalledTimes(1);
+    expect(flushQueuedEvents).toHaveBeenCalledTimes(1);
+    expect((flushQueuedPageviews as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (flushQueuedEvents as jest.Mock).mock.invocationCallOrder[0],
+    );
+  });
+});


### PR DESCRIPTION
## 関連Issue

- Closes #150
- Ref #147
- Ref #143

## 概要

Organic Searchのランディングページで `(not set)` になるセッションを調査した結果、`session_start` などは存在する一方、初回 `page_view` が欠けているケースが確認されました。

現行実装ではGA4初期化時に `send_page_view: false` を指定し、初回 `page_view` をReactの `useEffect()` から送信していたため、部分的なJavaScript実行やハイドレーション完了前の離脱時に欠損する余地がありました。

本PRでは次を変更しています。

- GA4の最初の `config` で自動 `page_view` を送信
- `Analytics` は初回表示をスキップし、App Routerのpathname変更時のみ送信
- クエリ文字列だけの変更、`pathname = null`、GA無効時は追加送信しない
- 初回送信とキューのflush順序に関する回帰テストを追加・更新

## 今回レビューしてほしい観点

- [ ] 初回 `page_view` とSPA遷移時の責務分担が妥当か
- [ ] 初回表示・パス遷移・クエリ変更で重複や欠損が生じないか
- [ ] `usePathname()` が `null` の場合の扱いが妥当か
- [ ] GA4スクリプト読み込み後のflush順序が維持されているか

## スクリーンショット/動画

UI変更はありません。

## 動作確認

- [x] `npm run lint`
- [x] `npm test -- --runInBand`（93件成功）
- [x] production build
- [x] production buildを起動したdataLayer確認
  - 初回表示: 自動 `config` 1件
  - SPAパス遷移: `page_path` 付き `config` が1件追加
  - クエリ文字列のみの変更: 追加送信なし

## 影響範囲

- GA4の初回 `page_view`
- App Routerのクライアントサイド遷移時の `page_view`
- UI、文言、SEOコンテンツ、カスタムイベント定義への変更なし

## チェックリスト

- [x] ESLintを通過
- [x] テストコードを追加・更新
- [x] production buildを通過
- [x] 依存関係・lockファイルの変更なし

## 備考

デプロイ後はIssue #147と同じ条件で、Organic Searchのランディングページ `(not set)` 率を継続確認します。
