### PR TITLE
feat: IndexNowによる本番URLの自動送信を有効化する

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -1,0 +1,32 @@
+name: Submit URLs to IndexNow
+
+on:
+  deployment_status:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: indexnow-production
+  cancel-in-progress: false
+
+jobs:
+  submit-indexnow:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'Production')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout deployed commit
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Submit production sitemap URLs
+        run: node scripts/submit-indexnow.js

--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -29,4 +29,6 @@ jobs:
           node-version: '20'
 
       - name: Submit production sitemap URLs
+        env:
+          DEPLOYMENT_URL: ${{ github.event.deployment_status.environment_url }}
         run: node scripts/submit-indexnow.js

--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Submit production sitemap URLs
         env:
-          DEPLOYMENT_URL: ${{ github.event.deployment_status.environment_url }}
+          EXPECTED_DEPLOYMENT_SHA: ${{ github.event.deployment.sha }}
         run: node scripts/submit-indexnow.js

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+/public/deployment-sha.txt
 
 # typescript
 *.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "prebuild": "node scripts/validate-site-url.js",
+    "prebuild": "node scripts/validate-site-url.js && node scripts/generate-deployment-marker.js",
     "build": "next build --turbopack",
     "postbuild": "next-sitemap",
     "start": "next start",

--- a/public/8541fb6911ebee21baedd14e76f5e0db.txt
+++ b/public/8541fb6911ebee21baedd14e76f5e0db.txt
@@ -1,0 +1,1 @@
+8541fb6911ebee21baedd14e76f5e0db

--- a/scripts/generate-deployment-marker.js
+++ b/scripts/generate-deployment-marker.js
@@ -1,0 +1,45 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { mkdirSync, rmSync, writeFileSync } = require('node:fs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { join } = require('node:path');
+
+const DEPLOYMENT_MARKER_FILENAME = 'deployment-sha.txt';
+
+/**
+ * @param {{ sha?: string, publicDir?: string }} options
+ * @returns {{ markerPath: string, written: boolean }}
+ */
+function generateDeploymentMarker({
+  sha = process.env.VERCEL_GIT_COMMIT_SHA,
+  publicDir = join(__dirname, '..', 'public'),
+} = {}) {
+  const markerPath = join(publicDir, DEPLOYMENT_MARKER_FILENAME);
+  const normalizedSha = sha?.trim();
+
+  if (!normalizedSha) {
+    rmSync(markerPath, { force: true });
+    return { markerPath, written: false };
+  }
+
+  if (!/^[0-9a-f]{40}$/iu.test(normalizedSha)) {
+    throw new Error('VERCEL_GIT_COMMIT_SHA must be a full 40-character Git SHA.');
+  }
+
+  mkdirSync(publicDir, { recursive: true });
+  writeFileSync(markerPath, `${normalizedSha}\n`, 'utf8');
+  return { markerPath, written: true };
+}
+
+if (require.main === module) {
+  const result = generateDeploymentMarker();
+  console.log(
+    result.written
+      ? `Generated ${result.markerPath}.`
+      : 'Skipped deployment marker generation because VERCEL_GIT_COMMIT_SHA is not set.'
+  );
+}
+
+module.exports = {
+  DEPLOYMENT_MARKER_FILENAME,
+  generateDeploymentMarker,
+};

--- a/scripts/submit-indexnow.js
+++ b/scripts/submit-indexnow.js
@@ -6,6 +6,8 @@ const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/indexnow';
 const MAX_URLS_PER_REQUEST = 10_000;
 const KEY_CHECK_ATTEMPTS = 12;
 const KEY_CHECK_INTERVAL_MS = 5_000;
+const INDEXNOW_ATTEMPTS = 3;
+const INDEXNOW_RETRY_INTERVAL_MS = 2_000;
 
 /**
  * @param {string} value
@@ -31,16 +33,66 @@ function extractLocs(xml) {
 }
 
 /**
+ * @param {string | undefined} deploymentUrl
+ * @returns {string}
+ */
+function getSitemapUrl(deploymentUrl) {
+  const sourceUrl = new URL(deploymentUrl?.trim() || SITE_URL);
+  if (sourceUrl.protocol !== 'https:') {
+    throw new Error(`The sitemap source must use HTTPS: ${sourceUrl.href}`);
+  }
+
+  return new URL('/sitemap.xml', sourceUrl.origin).href;
+}
+
+/**
+ * next-sitemap writes canonical production URLs into the sitemap index even
+ * when the file is served from a Vercel deployment URL. Preserve the nested
+ * path, but fetch it from the same deployment as the index.
+ *
+ * @param {string} nestedUrl
+ * @param {string} sitemapSourceOrigin
+ * @param {string} siteUrl
+ * @returns {string}
+ */
+function resolveNestedSitemapUrl(
+  nestedUrl,
+  sitemapSourceOrigin,
+  siteUrl = SITE_URL
+) {
+  const nested = new URL(nestedUrl);
+  const source = new URL(sitemapSourceOrigin);
+  const site = new URL(siteUrl);
+
+  if (nested.origin !== source.origin && nested.origin !== site.origin) {
+    throw new Error(
+      `Refusing to fetch a nested sitemap outside ${source.origin} or ${site.origin}: ${nestedUrl}`
+    );
+  }
+
+  return new URL(`${nested.pathname}${nested.search}`, source.origin).href;
+}
+
+/**
  * @param {string} sitemapUrl
  * @param {typeof fetch} fetchImpl
  * @param {Set<string>} visitedSitemaps
+ * @param {string} sitemapSourceOrigin
  * @returns {Promise<string[]>}
  */
 async function collectSitemapUrls(
   sitemapUrl,
   fetchImpl = fetch,
-  visitedSitemaps = new Set()
+  visitedSitemaps = new Set(),
+  sitemapSourceOrigin = new URL(sitemapUrl).origin
 ) {
+  const currentUrl = new URL(sitemapUrl);
+  if (currentUrl.origin !== new URL(sitemapSourceOrigin).origin) {
+    throw new Error(
+      `Refusing to fetch a sitemap outside ${new URL(sitemapSourceOrigin).origin}: ${sitemapUrl}`
+    );
+  }
+
   if (visitedSitemaps.has(sitemapUrl)) {
     return [];
   }
@@ -58,7 +110,14 @@ async function collectSitemapUrls(
 
   if (/<sitemapindex\b/iu.test(xml)) {
     const nestedUrls = await Promise.all(
-      locs.map((loc) => collectSitemapUrls(loc, fetchImpl, visitedSitemaps))
+      locs.map((loc) =>
+        collectSitemapUrls(
+          resolveNestedSitemapUrl(loc, sitemapSourceOrigin),
+          fetchImpl,
+          visitedSitemaps,
+          sitemapSourceOrigin
+        )
+      )
     );
     return [...new Set(nestedUrls.flat())];
   }
@@ -131,33 +190,84 @@ async function waitForPublishedKey({
 }
 
 /**
- * @param {{ fetchImpl?: typeof fetch }} options
- * @returns {Promise<{ status: number, urlCount: number }>}
+ * @param {number} status
+ * @returns {boolean}
  */
-async function submitIndexNow({ fetchImpl = fetch } = {}) {
-  await waitForPublishedKey({ fetchImpl });
+function isRetryableIndexNowStatus(status) {
+  return status === 429 || (status >= 500 && status <= 599);
+}
 
-  const sitemapUrls = await collectSitemapUrls(SITEMAP_URL, fetchImpl);
-  const urlList = validateSubmittedUrls(sitemapUrls);
-  const site = new URL(SITE_URL);
+/**
+ * @param {object} payload
+ * @param {{ fetchImpl?: typeof fetch, attempts?: number, intervalMs?: number, sleepImpl?: typeof sleep }} options
+ * @returns {Promise<Response>}
+ */
+async function postIndexNow(
+  payload,
+  {
+    fetchImpl = fetch,
+    attempts = INDEXNOW_ATTEMPTS,
+    intervalMs = INDEXNOW_RETRY_INTERVAL_MS,
+    sleepImpl = sleep,
+  } = {}
+) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const response = await fetchImpl(INDEXNOW_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+      body: JSON.stringify(payload),
+    });
 
-  const response = await fetchImpl(INDEXNOW_ENDPOINT, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json; charset=utf-8' },
-    body: JSON.stringify({
-      host: site.host,
-      key: INDEXNOW_KEY,
-      keyLocation: KEY_LOCATION,
-      urlList,
-    }),
-  });
+    if (response.status === 200 || response.status === 202) {
+      return response;
+    }
 
-  if (response.status !== 200 && response.status !== 202) {
+    if (isRetryableIndexNowStatus(response.status) && attempt < attempts) {
+      await sleepImpl(intervalMs);
+      continue;
+    }
+
     const responseBody = (await response.text()).slice(0, 500);
     throw new Error(
       `IndexNow submission failed (${response.status})${responseBody ? `: ${responseBody}` : ''}`
     );
   }
+
+  throw new Error('IndexNow submission failed after all retry attempts.');
+}
+
+/**
+ * @param {{ fetchImpl?: typeof fetch, deploymentUrl?: string, sleepImpl?: typeof sleep, indexNowAttempts?: number, indexNowRetryIntervalMs?: number }} options
+ * @returns {Promise<{ status: number, urlCount: number }>}
+ */
+async function submitIndexNow({
+  fetchImpl = fetch,
+  deploymentUrl = process.env.DEPLOYMENT_URL,
+  sleepImpl = sleep,
+  indexNowAttempts = INDEXNOW_ATTEMPTS,
+  indexNowRetryIntervalMs = INDEXNOW_RETRY_INTERVAL_MS,
+} = {}) {
+  await waitForPublishedKey({ fetchImpl, sleepImpl });
+
+  const sitemapUrl = getSitemapUrl(deploymentUrl);
+  const sitemapUrls = await collectSitemapUrls(sitemapUrl, fetchImpl);
+  const urlList = validateSubmittedUrls(sitemapUrls);
+  const site = new URL(SITE_URL);
+
+  const response = await postIndexNow(
+    {
+      host: site.host,
+      key: INDEXNOW_KEY,
+      keyLocation: KEY_LOCATION,
+      urlList,
+    },
+    {
+      fetchImpl,
+      attempts: indexNowAttempts,
+      intervalMs: indexNowRetryIntervalMs,
+      sleepImpl,
+    }
+  );
 
   return { status: response.status, urlCount: urlList.length };
 }
@@ -183,6 +293,9 @@ module.exports = {
   SITEMAP_URL,
   collectSitemapUrls,
   extractLocs,
+  getSitemapUrl,
+  postIndexNow,
+  resolveNestedSitemapUrl,
   submitIndexNow,
   validateSubmittedUrls,
   waitForPublishedKey,

--- a/scripts/submit-indexnow.js
+++ b/scripts/submit-indexnow.js
@@ -1,11 +1,14 @@
 const SITE_URL = 'https://cat-tools.catnote.tokyo';
 const INDEXNOW_KEY = '8541fb6911ebee21baedd14e76f5e0db';
 const KEY_LOCATION = `${SITE_URL}/${INDEXNOW_KEY}.txt`;
+const DEPLOYMENT_MARKER_URL = `${SITE_URL}/deployment-sha.txt`;
 const SITEMAP_URL = `${SITE_URL}/sitemap.xml`;
 const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/indexnow';
 const MAX_URLS_PER_REQUEST = 10_000;
 const KEY_CHECK_ATTEMPTS = 12;
 const KEY_CHECK_INTERVAL_MS = 5_000;
+const DEPLOYMENT_CHECK_ATTEMPTS = 24;
+const DEPLOYMENT_CHECK_INTERVAL_MS = 5_000;
 const INDEXNOW_ATTEMPTS = 3;
 const INDEXNOW_RETRY_INTERVAL_MS = 2_000;
 
@@ -30,47 +33,6 @@ function extractLocs(xml) {
   return [...xml.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/giu)].map((match) =>
     decodeXml(match[1].trim())
   );
-}
-
-/**
- * @param {string | undefined} deploymentUrl
- * @returns {string}
- */
-function getSitemapUrl(deploymentUrl) {
-  const sourceUrl = new URL(deploymentUrl?.trim() || SITE_URL);
-  if (sourceUrl.protocol !== 'https:') {
-    throw new Error(`The sitemap source must use HTTPS: ${sourceUrl.href}`);
-  }
-
-  return new URL('/sitemap.xml', sourceUrl.origin).href;
-}
-
-/**
- * next-sitemap writes canonical production URLs into the sitemap index even
- * when the file is served from a Vercel deployment URL. Preserve the nested
- * path, but fetch it from the same deployment as the index.
- *
- * @param {string} nestedUrl
- * @param {string} sitemapSourceOrigin
- * @param {string} siteUrl
- * @returns {string}
- */
-function resolveNestedSitemapUrl(
-  nestedUrl,
-  sitemapSourceOrigin,
-  siteUrl = SITE_URL
-) {
-  const nested = new URL(nestedUrl);
-  const source = new URL(sitemapSourceOrigin);
-  const site = new URL(siteUrl);
-
-  if (nested.origin !== source.origin && nested.origin !== site.origin) {
-    throw new Error(
-      `Refusing to fetch a nested sitemap outside ${source.origin} or ${site.origin}: ${nestedUrl}`
-    );
-  }
-
-  return new URL(`${nested.pathname}${nested.search}`, source.origin).href;
 }
 
 /**
@@ -110,14 +72,19 @@ async function collectSitemapUrls(
 
   if (/<sitemapindex\b/iu.test(xml)) {
     const nestedUrls = await Promise.all(
-      locs.map((loc) =>
-        collectSitemapUrls(
-          resolveNestedSitemapUrl(loc, sitemapSourceOrigin),
+      locs.map((loc) => {
+        if (new URL(loc).origin !== new URL(sitemapSourceOrigin).origin) {
+          throw new Error(
+            `Refusing to fetch a nested sitemap outside ${new URL(sitemapSourceOrigin).origin}: ${loc}`
+          );
+        }
+        return collectSitemapUrls(
+          loc,
           fetchImpl,
           visitedSitemaps,
           sitemapSourceOrigin
-        )
-      )
+        );
+      })
     );
     return [...new Set(nestedUrls.flat())];
   }
@@ -159,6 +126,54 @@ function validateSubmittedUrls(urls, siteUrl = SITE_URL) {
  */
 function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+/**
+ * @param {{ expectedSha?: string, fetchImpl?: typeof fetch, attempts?: number, intervalMs?: number, sleepImpl?: typeof sleep }} options
+ * @returns {Promise<void>}
+ */
+async function waitForExpectedDeployment({
+  expectedSha = process.env.EXPECTED_DEPLOYMENT_SHA,
+  fetchImpl = fetch,
+  attempts = DEPLOYMENT_CHECK_ATTEMPTS,
+  intervalMs = DEPLOYMENT_CHECK_INTERVAL_MS,
+  sleepImpl = sleep,
+} = {}) {
+  const normalizedExpectedSha = expectedSha?.trim();
+  if (!normalizedExpectedSha) {
+    return;
+  }
+  if (!/^[0-9a-f]{40}$/iu.test(normalizedExpectedSha)) {
+    throw new Error('EXPECTED_DEPLOYMENT_SHA must be a full 40-character Git SHA.');
+  }
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const markerUrl = new URL(DEPLOYMENT_MARKER_URL);
+      markerUrl.searchParams.set('expected', normalizedExpectedSha);
+      markerUrl.searchParams.set('attempt', String(attempt));
+      const response = await fetchImpl(markerUrl, {
+        cache: 'no-store',
+        headers: { 'cache-control': 'no-cache' },
+      });
+      if (
+        response.ok &&
+        (await response.text()).trim() === normalizedExpectedSha
+      ) {
+        return;
+      }
+    } catch {
+      // The production alias or marker may not be ready yet.
+    }
+
+    if (attempt < attempts) {
+      await sleepImpl(intervalMs);
+    }
+  }
+
+  throw new Error(
+    `Production did not publish deployment ${normalizedExpectedSha} at ${DEPLOYMENT_MARKER_URL}`
+  );
 }
 
 /**
@@ -237,20 +252,24 @@ async function postIndexNow(
 }
 
 /**
- * @param {{ fetchImpl?: typeof fetch, deploymentUrl?: string, sleepImpl?: typeof sleep, indexNowAttempts?: number, indexNowRetryIntervalMs?: number }} options
+ * @param {{ fetchImpl?: typeof fetch, expectedDeploymentSha?: string, sleepImpl?: typeof sleep, indexNowAttempts?: number, indexNowRetryIntervalMs?: number }} options
  * @returns {Promise<{ status: number, urlCount: number }>}
  */
 async function submitIndexNow({
   fetchImpl = fetch,
-  deploymentUrl = process.env.DEPLOYMENT_URL,
+  expectedDeploymentSha = process.env.EXPECTED_DEPLOYMENT_SHA,
   sleepImpl = sleep,
   indexNowAttempts = INDEXNOW_ATTEMPTS,
   indexNowRetryIntervalMs = INDEXNOW_RETRY_INTERVAL_MS,
 } = {}) {
+  await waitForExpectedDeployment({
+    expectedSha: expectedDeploymentSha,
+    fetchImpl,
+    sleepImpl,
+  });
   await waitForPublishedKey({ fetchImpl, sleepImpl });
 
-  const sitemapUrl = getSitemapUrl(deploymentUrl);
-  const sitemapUrls = await collectSitemapUrls(sitemapUrl, fetchImpl);
+  const sitemapUrls = await collectSitemapUrls(SITEMAP_URL, fetchImpl);
   const urlList = validateSubmittedUrls(sitemapUrls);
   const site = new URL(SITE_URL);
 
@@ -287,16 +306,16 @@ if (require.main === module) {
 }
 
 module.exports = {
+  DEPLOYMENT_MARKER_URL,
   INDEXNOW_KEY,
   INDEXNOW_ENDPOINT,
   KEY_LOCATION,
   SITEMAP_URL,
   collectSitemapUrls,
   extractLocs,
-  getSitemapUrl,
   postIndexNow,
-  resolveNestedSitemapUrl,
   submitIndexNow,
   validateSubmittedUrls,
+  waitForExpectedDeployment,
   waitForPublishedKey,
 };

--- a/scripts/submit-indexnow.js
+++ b/scripts/submit-indexnow.js
@@ -1,0 +1,189 @@
+const SITE_URL = 'https://cat-tools.catnote.tokyo';
+const INDEXNOW_KEY = '8541fb6911ebee21baedd14e76f5e0db';
+const KEY_LOCATION = `${SITE_URL}/${INDEXNOW_KEY}.txt`;
+const SITEMAP_URL = `${SITE_URL}/sitemap.xml`;
+const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/indexnow';
+const MAX_URLS_PER_REQUEST = 10_000;
+const KEY_CHECK_ATTEMPTS = 12;
+const KEY_CHECK_INTERVAL_MS = 5_000;
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function decodeXml(value) {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'");
+}
+
+/**
+ * @param {string} xml
+ * @returns {string[]}
+ */
+function extractLocs(xml) {
+  return [...xml.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/giu)].map((match) =>
+    decodeXml(match[1].trim())
+  );
+}
+
+/**
+ * @param {string} sitemapUrl
+ * @param {typeof fetch} fetchImpl
+ * @param {Set<string>} visitedSitemaps
+ * @returns {Promise<string[]>}
+ */
+async function collectSitemapUrls(
+  sitemapUrl,
+  fetchImpl = fetch,
+  visitedSitemaps = new Set()
+) {
+  if (visitedSitemaps.has(sitemapUrl)) {
+    return [];
+  }
+  visitedSitemaps.add(sitemapUrl);
+
+  const response = await fetchImpl(sitemapUrl, {
+    headers: { accept: 'application/xml, text/xml' },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch sitemap (${response.status}): ${sitemapUrl}`);
+  }
+
+  const xml = await response.text();
+  const locs = extractLocs(xml);
+
+  if (/<sitemapindex\b/iu.test(xml)) {
+    const nestedUrls = await Promise.all(
+      locs.map((loc) => collectSitemapUrls(loc, fetchImpl, visitedSitemaps))
+    );
+    return [...new Set(nestedUrls.flat())];
+  }
+
+  return [...new Set(locs)];
+}
+
+/**
+ * @param {string[]} urls
+ * @param {string} siteUrl
+ * @returns {string[]}
+ */
+function validateSubmittedUrls(urls, siteUrl = SITE_URL) {
+  const site = new URL(siteUrl);
+  const uniqueUrls = [...new Set(urls)];
+
+  if (uniqueUrls.length === 0) {
+    throw new Error('The sitemap did not contain any URLs to submit.');
+  }
+  if (uniqueUrls.length > MAX_URLS_PER_REQUEST) {
+    throw new Error(
+      `The sitemap contains ${uniqueUrls.length} URLs; IndexNow accepts at most ${MAX_URLS_PER_REQUEST} per request.`
+    );
+  }
+
+  for (const value of uniqueUrls) {
+    const url = new URL(value);
+    if (url.protocol !== site.protocol || url.host !== site.host) {
+      throw new Error(`Refusing to submit a URL outside ${site.origin}: ${value}`);
+    }
+  }
+
+  return uniqueUrls;
+}
+
+/**
+ * @param {number} milliseconds
+ * @returns {Promise<void>}
+ */
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+/**
+ * @param {{ fetchImpl?: typeof fetch, attempts?: number, intervalMs?: number, sleepImpl?: typeof sleep }} options
+ * @returns {Promise<void>}
+ */
+async function waitForPublishedKey({
+  fetchImpl = fetch,
+  attempts = KEY_CHECK_ATTEMPTS,
+  intervalMs = KEY_CHECK_INTERVAL_MS,
+  sleepImpl = sleep,
+} = {}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(KEY_LOCATION, { cache: 'no-store' });
+      if (response.ok && (await response.text()).trim() === INDEXNOW_KEY) {
+        return;
+      }
+    } catch {
+      // The production alias can take a few seconds to point to the new deployment.
+    }
+
+    if (attempt < attempts) {
+      await sleepImpl(intervalMs);
+    }
+  }
+
+  throw new Error(`IndexNow key is not publicly available at ${KEY_LOCATION}`);
+}
+
+/**
+ * @param {{ fetchImpl?: typeof fetch }} options
+ * @returns {Promise<{ status: number, urlCount: number }>}
+ */
+async function submitIndexNow({ fetchImpl = fetch } = {}) {
+  await waitForPublishedKey({ fetchImpl });
+
+  const sitemapUrls = await collectSitemapUrls(SITEMAP_URL, fetchImpl);
+  const urlList = validateSubmittedUrls(sitemapUrls);
+  const site = new URL(SITE_URL);
+
+  const response = await fetchImpl(INDEXNOW_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({
+      host: site.host,
+      key: INDEXNOW_KEY,
+      keyLocation: KEY_LOCATION,
+      urlList,
+    }),
+  });
+
+  if (response.status !== 200 && response.status !== 202) {
+    const responseBody = (await response.text()).slice(0, 500);
+    throw new Error(
+      `IndexNow submission failed (${response.status})${responseBody ? `: ${responseBody}` : ''}`
+    );
+  }
+
+  return { status: response.status, urlCount: urlList.length };
+}
+
+async function run() {
+  const result = await submitIndexNow();
+  console.log(
+    `IndexNow accepted ${result.urlCount} URLs with HTTP ${result.status}.`
+  );
+}
+
+if (require.main === module) {
+  run().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  INDEXNOW_KEY,
+  INDEXNOW_ENDPOINT,
+  KEY_LOCATION,
+  SITEMAP_URL,
+  collectSitemapUrls,
+  extractLocs,
+  submitIndexNow,
+  validateSubmittedUrls,
+  waitForPublishedKey,
+};

--- a/tests/unit/scripts/generate-deployment-marker.test.ts
+++ b/tests/unit/scripts/generate-deployment-marker.test.ts
@@ -1,0 +1,38 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as markerModule from '../../../scripts/generate-deployment-marker';
+
+const { DEPLOYMENT_MARKER_FILENAME, generateDeploymentMarker } = markerModule;
+
+describe('generate-deployment-marker', () => {
+  let publicDir: string;
+
+  beforeEach(() => {
+    publicDir = mkdtempSync(join(tmpdir(), 'cat-tools-marker-'));
+  });
+
+  afterEach(() => {
+    rmSync(publicDir, { recursive: true, force: true });
+  });
+
+  test('Vercelのfull commit SHAを公開markerへ書き込む', () => {
+    const sha = 'a'.repeat(40);
+
+    expect(generateDeploymentMarker({ sha, publicDir })).toEqual({
+      markerPath: join(publicDir, DEPLOYMENT_MARKER_FILENAME),
+      written: true,
+    });
+    expect(
+      readFileSync(join(publicDir, DEPLOYMENT_MARKER_FILENAME), 'utf8')
+    ).toBe(`${sha}\n`);
+  });
+
+  test('SHA未設定時は古いmarkerを残さない', () => {
+    const markerPath = join(publicDir, DEPLOYMENT_MARKER_FILENAME);
+    writeFileSync(markerPath, `${'b'.repeat(40)}\n`, 'utf8');
+
+    expect(generateDeploymentMarker({ sha: '', publicDir }).written).toBe(false);
+    expect(existsSync(markerPath)).toBe(false);
+  });
+});

--- a/tests/unit/scripts/submit-indexnow.test.ts
+++ b/tests/unit/scripts/submit-indexnow.test.ts
@@ -6,6 +6,8 @@ const {
   SITEMAP_URL,
   collectSitemapUrls,
   extractLocs,
+  getSitemapUrl,
+  postIndexNow,
   submitIndexNow,
   validateSubmittedUrls,
   waitForPublishedKey,
@@ -51,6 +53,63 @@ describe('submit-indexnow', () => {
     ]);
   });
 
+  test('Vercel固有URLからsitemap indexとnested sitemapを取得する', async () => {
+    const deploymentUrl = 'https://cat-tools-example.vercel.app';
+    const deploymentSitemapUrl = `${deploymentUrl}/sitemap.xml`;
+    const deploymentNestedUrl = `${deploymentUrl}/sitemap-0.xml`;
+    const fetchImpl = jest.fn(async (url: string | URL | Request) => {
+      const value = String(url);
+      if (value === deploymentSitemapUrl) {
+        return response(`
+          <sitemapindex>
+            <sitemap><loc>https://cat-tools.catnote.tokyo/sitemap-0.xml</loc></sitemap>
+          </sitemapindex>
+        `);
+      }
+      if (value === deploymentNestedUrl) {
+        return response(`
+          <urlset>
+            <url><loc>https://cat-tools.catnote.tokyo/new-page</loc></url>
+          </urlset>
+        `);
+      }
+      return response('unexpected URL', 500);
+    });
+
+    await expect(
+      collectSitemapUrls(deploymentSitemapUrl, fetchImpl as typeof fetch)
+    ).resolves.toEqual(['https://cat-tools.catnote.tokyo/new-page']);
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      deploymentNestedUrl,
+      expect.any(Object)
+    );
+    expect(fetchImpl).not.toHaveBeenCalledWith(
+      'https://cat-tools.catnote.tokyo/sitemap-0.xml',
+      expect.anything()
+    );
+  });
+
+  test('許可されないoriginのnested sitemapはfetch前に拒否する', async () => {
+    const fetchImpl = jest.fn(async () =>
+      response(`
+        <sitemapindex>
+          <sitemap><loc>https://example.com/sitemap.xml</loc></sitemap>
+        </sitemapindex>
+      `)
+    );
+
+    await expect(
+      collectSitemapUrls(SITEMAP_URL, fetchImpl as typeof fetch)
+    ).rejects.toThrow('Refusing to fetch a nested sitemap outside');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('DEPLOYMENT_URLがなければProduction sitemapへfallbackする', () => {
+    expect(getSitemapUrl(undefined)).toBe(SITEMAP_URL);
+    expect(getSitemapUrl('')).toBe(SITEMAP_URL);
+  });
+
   test('サイト外URLの送信を拒否する', () => {
     expect(() =>
       validateSubmittedUrls(['https://example.com/page'])
@@ -75,11 +134,13 @@ describe('submit-indexnow', () => {
     expect(sleepImpl).toHaveBeenCalledTimes(1);
   });
 
-  test('公開sitemapのURLをIndexNowへ一括送信する', async () => {
+  test('今回デプロイされたsitemapのProduction URLをIndexNowへ一括送信する', async () => {
+    const deploymentUrl = 'https://cat-tools-example.vercel.app';
+    const deploymentSitemapUrl = `${deploymentUrl}/sitemap.xml`;
     const fetchImpl = jest.fn(async (url: string | URL | Request, init?: RequestInit) => {
       const value = String(url);
       if (value === KEY_LOCATION) return response(INDEXNOW_KEY);
-      if (value === SITEMAP_URL) {
+      if (value === deploymentSitemapUrl) {
         return response(`
           <urlset>
             <url><loc>https://cat-tools.catnote.tokyo/</loc></url>
@@ -104,7 +165,53 @@ describe('submit-indexnow', () => {
     });
 
     await expect(
-      submitIndexNow({ fetchImpl: fetchImpl as typeof fetch })
+      submitIndexNow({
+        fetchImpl: fetchImpl as typeof fetch,
+        deploymentUrl,
+        sleepImpl: jest.fn().mockResolvedValue(undefined),
+      })
     ).resolves.toEqual({ status: 202, urlCount: 2 });
+  });
+
+  test('IndexNowの429と5xxを待機して再試行する', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(response('rate limited', 429))
+      .mockResolvedValueOnce(response('temporary failure', 503))
+      .mockResolvedValueOnce(response('', 200));
+    const sleepImpl = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      postIndexNow(
+        { host: 'cat-tools.catnote.tokyo', urlList: [] },
+        {
+          fetchImpl: fetchImpl as typeof fetch,
+          attempts: 3,
+          intervalMs: 0,
+          sleepImpl,
+        }
+      )
+    ).resolves.toMatchObject({ status: 200 });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(sleepImpl).toHaveBeenCalledTimes(2);
+  });
+
+  test('IndexNowの恒久的な4xxは再試行しない', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(response('invalid key', 403));
+    const sleepImpl = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      postIndexNow(
+        { host: 'cat-tools.catnote.tokyo', urlList: [] },
+        {
+          fetchImpl: fetchImpl as typeof fetch,
+          attempts: 3,
+          intervalMs: 0,
+          sleepImpl,
+        }
+      )
+    ).rejects.toThrow('IndexNow submission failed (403): invalid key');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(sleepImpl).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/scripts/submit-indexnow.test.ts
+++ b/tests/unit/scripts/submit-indexnow.test.ts
@@ -1,15 +1,16 @@
 import * as submitIndexNowModule from '../../../scripts/submit-indexnow';
 const {
+  DEPLOYMENT_MARKER_URL,
   INDEXNOW_KEY,
   INDEXNOW_ENDPOINT,
   KEY_LOCATION,
   SITEMAP_URL,
   collectSitemapUrls,
   extractLocs,
-  getSitemapUrl,
   postIndexNow,
   submitIndexNow,
   validateSubmittedUrls,
+  waitForExpectedDeployment,
   waitForPublishedKey,
 } = submitIndexNowModule;
 
@@ -53,43 +54,6 @@ describe('submit-indexnow', () => {
     ]);
   });
 
-  test('Vercel固有URLからsitemap indexとnested sitemapを取得する', async () => {
-    const deploymentUrl = 'https://cat-tools-example.vercel.app';
-    const deploymentSitemapUrl = `${deploymentUrl}/sitemap.xml`;
-    const deploymentNestedUrl = `${deploymentUrl}/sitemap-0.xml`;
-    const fetchImpl = jest.fn(async (url: string | URL | Request) => {
-      const value = String(url);
-      if (value === deploymentSitemapUrl) {
-        return response(`
-          <sitemapindex>
-            <sitemap><loc>https://cat-tools.catnote.tokyo/sitemap-0.xml</loc></sitemap>
-          </sitemapindex>
-        `);
-      }
-      if (value === deploymentNestedUrl) {
-        return response(`
-          <urlset>
-            <url><loc>https://cat-tools.catnote.tokyo/new-page</loc></url>
-          </urlset>
-        `);
-      }
-      return response('unexpected URL', 500);
-    });
-
-    await expect(
-      collectSitemapUrls(deploymentSitemapUrl, fetchImpl as typeof fetch)
-    ).resolves.toEqual(['https://cat-tools.catnote.tokyo/new-page']);
-    expect(fetchImpl).toHaveBeenNthCalledWith(
-      2,
-      deploymentNestedUrl,
-      expect.any(Object)
-    );
-    expect(fetchImpl).not.toHaveBeenCalledWith(
-      'https://cat-tools.catnote.tokyo/sitemap-0.xml',
-      expect.anything()
-    );
-  });
-
   test('許可されないoriginのnested sitemapはfetch前に拒否する', async () => {
     const fetchImpl = jest.fn(async () =>
       response(`
@@ -103,11 +67,6 @@ describe('submit-indexnow', () => {
       collectSitemapUrls(SITEMAP_URL, fetchImpl as typeof fetch)
     ).rejects.toThrow('Refusing to fetch a nested sitemap outside');
     expect(fetchImpl).toHaveBeenCalledTimes(1);
-  });
-
-  test('DEPLOYMENT_URLがなければProduction sitemapへfallbackする', () => {
-    expect(getSitemapUrl(undefined)).toBe(SITEMAP_URL);
-    expect(getSitemapUrl('')).toBe(SITEMAP_URL);
   });
 
   test('サイト外URLの送信を拒否する', () => {
@@ -134,13 +93,38 @@ describe('submit-indexnow', () => {
     expect(sleepImpl).toHaveBeenCalledTimes(1);
   });
 
-  test('今回デプロイされたsitemapのProduction URLをIndexNowへ一括送信する', async () => {
-    const deploymentUrl = 'https://cat-tools-example.vercel.app';
-    const deploymentSitemapUrl = `${deploymentUrl}/sitemap.xml`;
+  test('markerが期待SHAと一致するまでProduction aliasを再確認する', async () => {
+    const expectedSha = 'a'.repeat(40);
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(response('b'.repeat(40)))
+      .mockResolvedValueOnce(response(expectedSha));
+    const sleepImpl = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      waitForExpectedDeployment({
+        expectedSha,
+        fetchImpl: fetchImpl as typeof fetch,
+        attempts: 2,
+        intervalMs: 0,
+        sleepImpl,
+      })
+    ).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(String(fetchImpl.mock.calls[0][0])).toContain(
+      `${DEPLOYMENT_MARKER_URL}?expected=${expectedSha}&attempt=1`
+    );
+    expect(String(fetchImpl.mock.calls[1][0])).toContain('attempt=2');
+    expect(sleepImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('marker一致後にProduction sitemapのURLをIndexNowへ一括送信する', async () => {
+    const expectedSha = 'a'.repeat(40);
     const fetchImpl = jest.fn(async (url: string | URL | Request, init?: RequestInit) => {
       const value = String(url);
+      if (value.startsWith(DEPLOYMENT_MARKER_URL)) return response(expectedSha);
       if (value === KEY_LOCATION) return response(INDEXNOW_KEY);
-      if (value === deploymentSitemapUrl) {
+      if (value === SITEMAP_URL) {
         return response(`
           <urlset>
             <url><loc>https://cat-tools.catnote.tokyo/</loc></url>
@@ -167,10 +151,42 @@ describe('submit-indexnow', () => {
     await expect(
       submitIndexNow({
         fetchImpl: fetchImpl as typeof fetch,
-        deploymentUrl,
+        expectedDeploymentSha: expectedSha,
         sleepImpl: jest.fn().mockResolvedValue(undefined),
       })
     ).resolves.toEqual({ status: 202, urlCount: 2 });
+    const fetchedUrls = fetchImpl.mock.calls.map(([url]) => String(url));
+    expect(fetchedUrls).toContain(SITEMAP_URL);
+    expect(fetchedUrls.some((url) => url.includes('.vercel.app'))).toBe(false);
+  });
+
+  test('EXPECTED_DEPLOYMENT_SHAがなければmarker待ちを省略する', async () => {
+    const fetchImpl = jest.fn(async (url: string | URL | Request) => {
+      const value = String(url);
+      if (value === KEY_LOCATION) return response(INDEXNOW_KEY);
+      if (value === SITEMAP_URL) {
+        return response(`
+          <urlset>
+            <url><loc>https://cat-tools.catnote.tokyo/</loc></url>
+          </urlset>
+        `);
+      }
+      if (value === INDEXNOW_ENDPOINT) return response('', 200);
+      return response('unexpected URL', 500);
+    });
+
+    await expect(
+      submitIndexNow({
+        fetchImpl: fetchImpl as typeof fetch,
+        expectedDeploymentSha: '',
+        sleepImpl: jest.fn().mockResolvedValue(undefined),
+      })
+    ).resolves.toEqual({ status: 200, urlCount: 1 });
+    expect(
+      fetchImpl.mock.calls.some(([url]) =>
+        String(url).startsWith(DEPLOYMENT_MARKER_URL)
+      )
+    ).toBe(false);
   });
 
   test('IndexNowの429と5xxを待機して再試行する', async () => {

--- a/tests/unit/scripts/submit-indexnow.test.ts
+++ b/tests/unit/scripts/submit-indexnow.test.ts
@@ -1,0 +1,110 @@
+import * as submitIndexNowModule from '../../../scripts/submit-indexnow';
+const {
+  INDEXNOW_KEY,
+  INDEXNOW_ENDPOINT,
+  KEY_LOCATION,
+  SITEMAP_URL,
+  collectSitemapUrls,
+  extractLocs,
+  submitIndexNow,
+  validateSubmittedUrls,
+  waitForPublishedKey,
+} = submitIndexNowModule;
+
+const response = (body: string, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  text: async () => body,
+});
+
+describe('submit-indexnow', () => {
+  test('sitemapのlocをXMLエンティティ込みで抽出する', () => {
+    expect(
+      extractLocs(
+        '<urlset><url><loc>https://cat-tools.catnote.tokyo/page?a=1&amp;b=2</loc></url></urlset>'
+      )
+    ).toEqual(['https://cat-tools.catnote.tokyo/page?a=1&b=2']);
+  });
+
+  test('sitemap indexを再帰的に読み、URLを重複排除する', async () => {
+    const fetchImpl = jest.fn(async (url: string | URL | Request) => {
+      const value = String(url);
+      if (value === SITEMAP_URL) {
+        return response(`
+          <sitemapindex>
+            <sitemap><loc>https://cat-tools.catnote.tokyo/sitemap-0.xml</loc></sitemap>
+          </sitemapindex>
+        `);
+      }
+      return response(`
+        <urlset>
+          <url><loc>https://cat-tools.catnote.tokyo/</loc></url>
+          <url><loc>https://cat-tools.catnote.tokyo/about</loc></url>
+          <url><loc>https://cat-tools.catnote.tokyo/about</loc></url>
+        </urlset>
+      `);
+    });
+
+    await expect(collectSitemapUrls(SITEMAP_URL, fetchImpl as typeof fetch)).resolves.toEqual([
+      'https://cat-tools.catnote.tokyo/',
+      'https://cat-tools.catnote.tokyo/about',
+    ]);
+  });
+
+  test('サイト外URLの送信を拒否する', () => {
+    expect(() =>
+      validateSubmittedUrls(['https://example.com/page'])
+    ).toThrow('Refusing to submit a URL outside');
+  });
+
+  test('公開キーが一致するまで再試行する', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(response('not-ready', 404))
+      .mockResolvedValueOnce(response(INDEXNOW_KEY));
+    const sleepImpl = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      waitForPublishedKey({
+        fetchImpl: fetchImpl as typeof fetch,
+        attempts: 2,
+        intervalMs: 0,
+        sleepImpl,
+      })
+    ).resolves.toBeUndefined();
+    expect(sleepImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('公開sitemapのURLをIndexNowへ一括送信する', async () => {
+    const fetchImpl = jest.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const value = String(url);
+      if (value === KEY_LOCATION) return response(INDEXNOW_KEY);
+      if (value === SITEMAP_URL) {
+        return response(`
+          <urlset>
+            <url><loc>https://cat-tools.catnote.tokyo/</loc></url>
+            <url><loc>https://cat-tools.catnote.tokyo/about</loc></url>
+          </urlset>
+        `);
+      }
+      if (value === INDEXNOW_ENDPOINT) {
+        const payload = JSON.parse(String(init?.body));
+        expect(payload).toEqual({
+          host: 'cat-tools.catnote.tokyo',
+          key: INDEXNOW_KEY,
+          keyLocation: KEY_LOCATION,
+          urlList: [
+            'https://cat-tools.catnote.tokyo/',
+            'https://cat-tools.catnote.tokyo/about',
+          ],
+        });
+        return response('', 202);
+      }
+      return response('unexpected URL', 500);
+    });
+
+    await expect(
+      submitIndexNow({ fetchImpl: fetchImpl as typeof fetch })
+    ).resolves.toEqual({ status: 202, urlCount: 2 });
+  });
+});


### PR DESCRIPTION
## 概要

IndexNowを有効化し、Vercelの本番デプロイ完了後にサイトURLを自動送信できるようにします。

## 変更内容

- IndexNow所有確認用のUTF-8キーファイルをサイト直下へ追加
- 公開キーを確認してからsitemapを再帰的に読み取る送信スクリプトを追加
- sitemap内のURLが同一オリジンであることと、10,000件以内であることを検証
- IndexNowのグローバルエンドポイントへURLを一括送信
- Vercelの`Production`デプロイ成功時だけ実行するGitHub Actionsを追加
- 手動再実行用に`workflow_dispatch`も用意
- キー確認、sitemap index、重複排除、サイト外URL拒否、HTTP 202応答を単体テストでカバー

## 自動送信フロー

1. このPRを`main`へマージ
2. VercelがProductionへデプロイ
3. VercelがGitHubへデプロイ成功イベントを通知
4. GitHub Actionsが本番URL上のキーファイルを確認
5. 本番sitemapからURLを取得
6. IndexNow APIへ一括送信

Previewデプロイやローカルビルドからは送信しません。VercelトークンやGitHub Secretsの追加も不要です。

## 背景

Bing Webmaster ToolsのIndexNow画面では、管理画面上のトグルではなく、公開キーファイルによる所有確認とAPI送信が必要です。ビルド中に送信すると新しいキーファイルやコンテンツがまだ本番公開されていない可能性があるため、VercelのProductionデプロイ成功イベントを起点にしています。

## 検証

- `npm run lint`
- `npm test -- --runInBand`（98 tests passed）
- `SITE_URL=https://cat-tools.catnote.tokyo npm run build`
- 生成sitemapから9 URLを取得し、同一オリジン検証が通ることを確認
- Workflow YAMLの構文確認
- 公開キーファイル名と内容の一致確認

## マージ後の確認

- キーファイルが本番URLで200応答し、本文がキーと一致すること
- `Submit URLs to IndexNow` Workflowが成功すること
- 初回はIndexNow APIからHTTP 202、検証済みの場合はHTTP 200が返り得る
- Bing Webmaster ToolsのIndexNow画面へ受信データが反映されること
