### PR TITLE
猫の必要給水量ページに体重別早見表と計算根拠を追加

### DIFF
--- a/src/app/calculate-cat-water-intake/CatWaterIntakeCalculator.tsx
+++ b/src/app/calculate-cat-water-intake/CatWaterIntakeCalculator.tsx
@@ -9,6 +9,11 @@ import { CALCULATE_CAT_WATER_INTAKE_PATH } from '@/constants/paths';
 import { WATER_INTAKE_UI_TEXT } from '@/constants/text';
 import { calculateCatWaterIntake, formatMl } from '@/lib/catWaterIntake';
 
+const WATER_INTAKE_REFERENCE_ROWS = [2, 3, 4, 5, 6, 7, 8].map((weightKg) => ({
+  weightKg,
+  totalWaterMl: calculateCatWaterIntake({ weightKg }).totalWaterMl,
+}));
+
 function parsePositiveOrZero(value: string) {
   const parsed = Number.parseFloat(value);
   if (!value.trim()) return null;
@@ -19,6 +24,62 @@ function parseRequiredPositive(value: string) {
   const parsed = Number.parseFloat(value);
   if (!value.trim()) return null;
   return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function WaterIntakeReferenceTable() {
+  const tableText = WATER_INTAKE_UI_TEXT.REFERENCE_TABLE;
+
+  return (
+    <section className="mt-8" aria-labelledby="water-intake-reference-table-title">
+      <h2
+        id="water-intake-reference-table-title"
+        className="text-xl md:text-2xl font-extrabold text-gray-900 text-balance"
+      >
+        {tableText.TITLE}
+      </h2>
+      <p className="mt-3 text-sm text-gray-700 leading-relaxed text-pretty">
+        {tableText.DESCRIPTION}
+      </p>
+
+      <div className="mt-5 overflow-x-auto">
+        <table className="w-full min-w-[32rem] border-collapse text-sm text-left tabular-nums">
+          <caption className="sr-only">{tableText.CAPTION}</caption>
+          <thead>
+            <tr className="border-b-2 border-pink-200 bg-pink-50">
+              <th scope="col" className="px-3 py-3 font-bold text-gray-900 whitespace-nowrap">
+                {tableText.HEADERS.WEIGHT}
+              </th>
+              <th scope="col" className="px-3 py-3 font-bold text-gray-900 whitespace-nowrap">
+                {tableText.HEADERS.RANGE}
+              </th>
+              <th scope="col" className="px-3 py-3 font-bold text-gray-900 whitespace-nowrap">
+                {tableText.HEADERS.MID}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {WATER_INTAKE_REFERENCE_ROWS.map(({ weightKg, totalWaterMl }) => (
+              <tr key={weightKg} className="border-b border-gray-200">
+                <th scope="row" className="px-3 py-3 font-semibold text-gray-900 whitespace-nowrap">
+                  {weightKg}kg
+                </th>
+                <td className="px-3 py-3 text-gray-700 whitespace-nowrap">
+                  {formatMl(totalWaterMl.min)}〜{formatMl(totalWaterMl.max)}mL/日
+                </td>
+                <td className="px-3 py-3 font-semibold text-gray-900 whitespace-nowrap">
+                  {formatMl(totalWaterMl.mid)}mL/日
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mt-4 rounded-xl border border-pink-200 bg-pink-50 p-4 text-sm text-pink-900 leading-relaxed text-pretty">
+        {tableText.NOTE}
+      </p>
+    </section>
+  );
 }
 
 function WaterIntakeSupplementaryContent() {
@@ -324,59 +385,73 @@ export default function CatWaterIntakeCalculator() {
           {WATER_INTAKE_UI_TEXT.HEADER.DESCRIPTION}
         </p>
 
-        <div className="surface border-none overflow-hidden border-b border-gray-200">
-          <div className="row flex flex-col gap-4">
-            <div className="flex flex-col gap-1.5">
-              <label htmlFor="weightInput" className="text-base font-bold text-gray-900">
-                {WATER_INTAKE_UI_TEXT.INPUT.WEIGHT_LABEL}
-              </label>
-              <input
-                id="weightInput"
-                type="text"
-                inputMode="decimal"
-                placeholder="例: 4.2"
-                value={weight}
-                onChange={(e) => onWeightChange(e.target.value)}
-                className="w-full h-14 px-6 border-2 border-pink-200 rounded-lg text-base text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-pink-600 focus:ring-opacity-35"
-              />
-              <div className="text-red-700 text-xs mt-1 min-h-[1.2em]" aria-live="polite">{errors.weight}</div>
-            </div>
+        <WaterIntakeReferenceTable />
 
-            <div className="flex flex-col gap-1.5">
-              <label htmlFor="dryFoodInput" className="text-base font-bold text-gray-900">
-                {WATER_INTAKE_UI_TEXT.INPUT.DRY_FOOD_LABEL}
-              </label>
-              <input
-                id="dryFoodInput"
-                type="text"
-                inputMode="decimal"
-                placeholder="例: 40"
-                value={dryFood}
-                onChange={(e) => onDryFoodChange(e.target.value)}
-                className="w-full h-14 px-6 border-2 border-pink-200 rounded-lg text-base text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-pink-600 focus:ring-opacity-35"
-              />
-              <div className="text-xs text-gray-500">{WATER_INTAKE_UI_TEXT.INPUT.OPTIONAL_HINT}</div>
-              <div className="text-red-700 text-xs mt-1 min-h-[1.2em]" aria-live="polite">{errors.dryFood}</div>
-            </div>
+        <section className="mt-10" aria-labelledby="water-intake-calculator-title">
+          <h2
+            id="water-intake-calculator-title"
+            className="text-xl md:text-2xl font-extrabold text-gray-900 text-balance"
+          >
+            {WATER_INTAKE_UI_TEXT.CALCULATOR.TITLE}
+          </h2>
+          <p className="mt-3 text-sm text-gray-700 leading-relaxed text-pretty">
+            {WATER_INTAKE_UI_TEXT.CALCULATOR.DESCRIPTION}
+          </p>
 
-            <div className="flex flex-col gap-1.5">
-              <label htmlFor="wetFoodInput" className="text-base font-bold text-gray-900">
-                {WATER_INTAKE_UI_TEXT.INPUT.WET_FOOD_LABEL}
-              </label>
-              <input
-                id="wetFoodInput"
-                type="text"
-                inputMode="decimal"
-                placeholder="例: 80"
-                value={wetFood}
-                onChange={(e) => onWetFoodChange(e.target.value)}
-                className="w-full h-14 px-6 border-2 border-pink-200 rounded-lg text-base text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-pink-600 focus:ring-opacity-35"
-              />
-              <div className="text-xs text-gray-500">{WATER_INTAKE_UI_TEXT.INPUT.OPTIONAL_HINT}</div>
-              <div className="text-red-700 text-xs mt-1 min-h-[1.2em]" aria-live="polite">{errors.wetFood}</div>
+          <div className="surface mt-5 border-none overflow-hidden border-b border-gray-200">
+            <div className="row flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="weightInput" className="text-base font-bold text-gray-900">
+                  {WATER_INTAKE_UI_TEXT.INPUT.WEIGHT_LABEL}
+                </label>
+                <input
+                  id="weightInput"
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="例: 4.2"
+                  value={weight}
+                  onChange={(e) => onWeightChange(e.target.value)}
+                  className="w-full h-14 px-6 border-2 border-pink-200 rounded-lg text-base text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-pink-600 focus:ring-opacity-35"
+                />
+                <div className="text-red-700 text-xs mt-1 min-h-[1.2em]" aria-live="polite">{errors.weight}</div>
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="dryFoodInput" className="text-base font-bold text-gray-900">
+                  {WATER_INTAKE_UI_TEXT.INPUT.DRY_FOOD_LABEL}
+                </label>
+                <input
+                  id="dryFoodInput"
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="例: 40"
+                  value={dryFood}
+                  onChange={(e) => onDryFoodChange(e.target.value)}
+                  className="w-full h-14 px-6 border-2 border-pink-200 rounded-lg text-base text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-pink-600 focus:ring-opacity-35"
+                />
+                <div className="text-xs text-gray-500">{WATER_INTAKE_UI_TEXT.INPUT.OPTIONAL_HINT}</div>
+                <div className="text-red-700 text-xs mt-1 min-h-[1.2em]" aria-live="polite">{errors.dryFood}</div>
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="wetFoodInput" className="text-base font-bold text-gray-900">
+                  {WATER_INTAKE_UI_TEXT.INPUT.WET_FOOD_LABEL}
+                </label>
+                <input
+                  id="wetFoodInput"
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="例: 80"
+                  value={wetFood}
+                  onChange={(e) => onWetFoodChange(e.target.value)}
+                  className="w-full h-14 px-6 border-2 border-pink-200 rounded-lg text-base text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-pink-600 focus:ring-opacity-35"
+                />
+                <div className="text-xs text-gray-500">{WATER_INTAKE_UI_TEXT.INPUT.OPTIONAL_HINT}</div>
+                <div className="text-red-700 text-xs mt-1 min-h-[1.2em]" aria-live="polite">{errors.wetFood}</div>
+              </div>
             </div>
           </div>
-        </div>
+        </section>
       </section>
 
       {result && (

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1106,6 +1106,24 @@ export const WATER_INTAKE_UI_TEXT = {
     DESCRIPTION:
       '体重から1日の総水分目標（参考幅）を算出し、フード量を入力した場合は食事由来の水分量（ドライ10%、ウェット78%）を差し引いて、器からの飲水目安を表示します。',
   },
+  REFERENCE_TABLE: {
+    TITLE: '猫の体重別・1日の総水分量早見表',
+    DESCRIPTION:
+      '本ツールで採用している計算基準に基づき、猫の1日の総水分量を、体重1kgあたり40〜60mL、中央目安50mLとして単純換算した参考表です。食事に含まれる水分も合わせた量であり、器から飲む水の量そのものではありません。',
+    CAPTION: '猫の体重2kgから8kgまでの1日の総水分量参考表',
+    HEADERS: {
+      WEIGHT: '体重',
+      RANGE: '総水分量の参考幅',
+      MID: '中央目安',
+    },
+    NOTE:
+      'この表は健康管理のための参考値です。子猫、シニア猫、妊娠・授乳中の猫、肥満・痩せ気味の猫、持病や治療中の猫では必要量が異なることがあります。フードに含まれる水分を差し引いた「器からの飲水目安」は、下の計算機で確認してください。',
+  },
+  CALCULATOR: {
+    TITLE: '体重とフード量から詳しく計算する',
+    DESCRIPTION:
+      'ドライフードとウェットフードの1日量を入力すると、食事に含まれる水分を差し引いた、器からの飲水目安を確認できます。',
+  },
   GUIDE: {
     WHAT_TITLE: 'このツールでできること',
     WHAT_DESCRIPTION:
@@ -1155,7 +1173,7 @@ export const WATER_INTAKE_UI_TEXT = {
     BASICS: {
       TITLE: '猫の1日に必要な水分量はどう決まる？',
       BODY: [
-        '猫の必要水分量は、一般的に体重1kgあたり40〜60mL程度がひとつの目安です。ただし、実際の猫の1日の水の量は、体格だけでなく生活環境や食事内容でも変わります。',
+        '本ツールでは、体重1kgあたり40〜60mLを1日の総水分量の参考幅として採用しています。これは確定的な正常値ではなく、実際の猫の1日の水の量は、体格だけでなく生活環境や食事内容でも変わります。',
         'とくにドライフード 水分は少なく、ウェットフード 水分は多いため、器から飲むべき量は同じ猫でも食事次第で変わります。このツールは、食事由来の水分を差し引いたうえで、器からの飲水量の目安を見やすくしています。',
       ],
       FACTORS: [
@@ -1241,19 +1259,29 @@ export const WATER_INTAKE_UI_TEXT = {
     REFERENCES: {
       TITLE: '計算方法の参考情報',
       BODY: [
-        'このページの給水量計算は、体重あたりの総水分目安と、フードに含まれる水分量を分けて考える構成です。',
-        '表示値は一般的な目安として扱い、普段の飲水傾向や体調変化とあわせて確認してください。',
+        '本ツールでは、1日の総水分量を体重1kgあたり40〜60mLの参考幅で計算し、50mL/kgを中央目安として表示しています。NRC由来の50〜60mL/kg/日は一般的に紹介される推奨値ですが、犬の必要量をもとにした推定で、食事内容、環境温度、活動量などを考慮していないという限界があります。Cornellの猫向け情報は約52mL/kg/日に相当します。',
+        '40mL/kg/日はAAHAの犬猫向け輸液ガイドラインで、猫の臨床上の維持水分量として用いられる値であり、健康な猫が経口摂取すべき最低量を示すものではありません。猫における最適な最低水分量は確立されておらず、実際の必要量は食事、環境、活動量、年齢、健康状態などによって変わります。',
       ],
       LINKS: [
+        {
+          LABEL: 'Journal of Animal Science: 猫の水分摂取に関するスコーピングレビュー',
+          URL: 'https://academic.oup.com/jas/article/doi/10.1093/jas/skaf434/8379605',
+          NOTE: 'NRCの推奨値の前提、猫の総水分摂取量と尿比重の関係、最適な最低量が確立されていないことの参考情報',
+        },
+        {
+          LABEL: 'Cornell Feline Health Center: Hydration',
+          URL: 'https://www.vet.cornell.edu/departments-centers-and-institutes/cornell-feline-health-center/health-information/feline-health-topics/hydration',
+          NOTE: '猫の水分摂取、ウェットフードとドライフードによる飲水量差、脱水サインの参考情報',
+        },
         {
           LABEL: 'Merck Veterinary Manual: Nutritional Requirements of Small Animals',
           URL: 'https://www.merckvetmanual.com/management-and-nutrition/nutrition-small-animals/nutritional-requirements-of-small-animals',
           NOTE: '犬猫の水分必要量、食事・環境・活動量・健康状態による個体差、ドライ/缶詰フードの水分量差の参考情報',
         },
         {
-          LABEL: 'Cornell Feline Health Center: Hydration',
-          URL: 'https://www.vet.cornell.edu/departments-centers-and-institutes/cornell-feline-health-center/health-information/feline-health-topics/hydration',
-          NOTE: '猫の水分摂取、ウェットフードとドライフードによる飲水量差、脱水サインの参考情報',
+          LABEL: '2024 AAHA Fluid Therapy Guidelines for Dogs and Cats',
+          URL: 'https://www.aaha.org/resources/2024-aaha-fluid-therapy-guidelines-for-dogs-and-cats/',
+          NOTE: '猫の臨床上の維持水分量と、個々の状態に応じて評価・調整する必要性の参考情報',
         },
       ],
     },

--- a/tests/e2e/specs/water-intake.spec.ts
+++ b/tests/e2e/specs/water-intake.spec.ts
@@ -3,6 +3,36 @@ import { test, expect } from '@playwright/test';
 const PAGE = '/calculate-cat-water-intake';
 
 test.describe('猫の必要給水量計算 E2E', () => {
+  test('入力前に体重別の総水分量早見表が表示される', async ({ page }) => {
+    await page.goto(PAGE);
+
+    await expect(page.getByRole('heading', { name: '猫の体重別・1日の総水分量早見表' })).toBeVisible();
+
+    const table = page.getByRole('table', { name: '猫の体重2kgから8kgまでの1日の総水分量参考表' });
+    await expect(table).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: '体重' })).toHaveAttribute('scope', 'col');
+    await expect(table.getByRole('columnheader', { name: '総水分量の参考幅' })).toHaveAttribute('scope', 'col');
+    await expect(table.getByRole('columnheader', { name: '中央目安' })).toHaveAttribute('scope', 'col');
+
+    const expectedRows = [
+      { weight: '2kg', range: '80〜120mL/日', mid: '100mL/日' },
+      { weight: '4kg', range: '160〜240mL/日', mid: '200mL/日' },
+      { weight: '8kg', range: '320〜480mL/日', mid: '400mL/日' },
+    ];
+
+    for (const expectedRow of expectedRows) {
+      const row = table.getByRole('row', { name: new RegExp(`^${expectedRow.weight}`) });
+      await expect(row.getByRole('rowheader', { name: expectedRow.weight })).toHaveAttribute('scope', 'row');
+      await expect(row).toContainText(expectedRow.range);
+      await expect(row).toContainText(expectedRow.mid);
+    }
+
+    await expect(page.getByText('食事に含まれる水分も合わせた量であり')).toBeVisible();
+    await expect(page.getByText('器から飲む水の量そのものではありません')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '体重とフード量から詳しく計算する' })).toBeVisible();
+    await expect(page.locator('#weightInput')).toHaveValue('');
+  });
+
   test('参考情報セクションと外部リンクが表示される', async ({ page }) => {
     await page.goto(PAGE);
 
@@ -27,5 +57,39 @@ test.describe('猫の必要給水量計算 E2E', () => {
     );
     await expect(cornellLink).toHaveAttribute('target', '_blank');
     await expect(cornellLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const journalLink = page.getByRole('link', {
+      name: 'Journal of Animal Science: 猫の水分摂取に関するスコーピングレビュー',
+    });
+    await expect(journalLink).toHaveAttribute(
+      'href',
+      'https://academic.oup.com/jas/article/doi/10.1093/jas/skaf434/8379605',
+    );
+    await expect(journalLink).toHaveAttribute('target', '_blank');
+    await expect(journalLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const aahaLink = page.getByRole('link', { name: '2024 AAHA Fluid Therapy Guidelines for Dogs and Cats' });
+    await expect(aahaLink).toHaveAttribute(
+      'href',
+      'https://www.aaha.org/resources/2024-aaha-fluid-therapy-guidelines-for-dogs-and-cats/',
+    );
+    await expect(aahaLink).toHaveAttribute('target', '_blank');
+    await expect(aahaLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('入力・計算結果・URL同期が従来どおり動作する', async ({ page }) => {
+    await page.goto(PAGE);
+
+    await page.locator('#weightInput').fill('4');
+    await expect(page).toHaveURL(/weight=4/);
+    await page.locator('#dryFoodInput').fill('40');
+    await expect(page).toHaveURL(/dry=40/);
+    await page.locator('#wetFoodInput').fill('80');
+
+    await expect(page).toHaveURL(`${PAGE}?weight=4&dry=40&wet=80`);
+    await expect(page.locator('#totalWaterResult')).toContainText('160〜240 mL');
+    await expect(page.getByText('中央目安 200 mL', { exact: true })).toBeVisible();
+    await expect(page.locator('#foodWaterResult')).toContainText('66.4 mL');
+    await expect(page.locator('#drinkTargetResult')).toContainText('93.6〜173.6');
   });
 });


### PR DESCRIPTION
## 関連Issue
- Closes #153

## 概要
- `/calculate-cat-water-intake` のH1・導入文の後に、2〜8kgの体重別総水分量早見表を追加
- 早見表の数値を既存の `calculateCatWaterIntake()` から生成し、計算値の二重管理を回避
- 「総水分量」と「器からの飲水量」の違い、40〜60mL/kg/日の前提と限界を追記
- Journal of Animal Scienceと2024 AAHA Fluid Therapy Guidelinesを参考資料へ追加
- 表の初期表示、代表値、アクセシビリティ、外部リンク、既存計算・URL同期をPlaywrightで検証

## 今回レビューしてほしい観点（必要なものだけ残す）
- [ ] 正確性（早見表が既存の40・50・60mL/kg/日計算と一致しているか）
- [ ] 医療・健康情報の表現（参考幅を確定的な正常値や必須量と誤認させないか）
- [ ] アクセシビリティ（`table`、`caption`、`th scope`、見出し階層が適切か）
- [ ] 回帰（既存の入力、計算結果、URL同期を壊していないか）

## スクリーンショット/動画（任意）
- Playwrightでデスクトップ1280px・モバイル393pxを確認
- モバイルではページ全体を横にあふれさせず、表のみ横スクロールすることを確認

## 動作確認
- [x] デスクトップChromiumでの表示/操作
- [x] スマホ幅Chromiumでの表示/操作
- [x] `SITE_URL=https://cat-tools.catnote.tokyo npm run build`

## 影響範囲
- `/calculate-cat-water-intake` の本文、早見表、計算フォーム上部の説明
- 給水量ページのE2Eテスト
- 計算ロジック、入力仕様、URLクエリ、メタデータ、FAQ、sitemapは変更なし

## チェックリスト
- [x] ESLintを通過
- [x] Jest（13 suites / 113 tests）を通過
- [x] Playwright対象テスト（デスクトップ・モバイル計6件）を通過
- [x] テストコードを追加
- [x] 文言・日本語確認

## 備考
- `40〜60mL/kg/日` は本ツールで採用する参考幅として記載し、健康な猫の確定的な正常値や経口摂取最低量とは表現していません。
